### PR TITLE
Reduce the amount of effort needed to create docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules
 npm-debug.log
+db-data/
+cache-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,11 @@ COPY package*.json ./
 RUN npm ci --only=production
 
 # Bundle app source
-COPY . .
+COPY --chown=node:node . .
+
 
 # Install 7d2d item icons
-USER root
-RUN chmod +x /usr/src/app/scripts/itemIconsUpdate.sh
-RUN /usr/src/app/scripts/itemIconsUpdate.sh
-RUN chown -R node:node /usr/src/app
-USER node
+RUN bash /usr/src/app/scripts/itemIconsUpdate.sh
 
 EXPOSE 1337
 CMD [ "node", "app.js" ]

--- a/scripts/itemIconsUpdate.sh
+++ b/scripts/itemIconsUpdate.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
-cd assets/images
-rm -rf sdtdIcons/
-
-LOCATION=$(curl -s https://api.github.com/repos/CatalysmsServerManager/7dtd-icons/releases/latest \
-| grep "tag_name" \
-| awk '{print "https://github.com/CatalysmsServerManager/7dtd-icons/releases/download/" substr($2, 2, length($2)-3) "/sdtdIcons.tar.gz"}') \
-; echo "Downloading icons from $LOCATION" \
-; curl -L -o icons.tar.gz "$LOCATION" \
-; tar -xzf icons.tar.gz sdtdIcons  \
-; rm icons.tar.gz \
+set -ex
+rm -rf assets/images/sdtdIcons/
+mkdir -p assets/images/sdtdIcons/
+curl -qsL https://github.com/CatalysmsServerManager/7dtd-icons/releases/latest/download/sdtdIcons.tar.gz | tar xzf - -C assets/images


### PR DESCRIPTION
I found docker-compose super slow to build the image.

* Ignore db-data and cache-data so it doesn't need to copy it into the image
* Copy with chown so you don't need to do the expensive chown after npm install
* Reduce the complexity of itemIconsUpdate (add -e to bail on error and -x to debug whats going on)
