### PR TITLE
Refactor so calls to 7daystodie-api-wrapper can be tested

### DIFF
--- a/api/hooks/sdtdLogs/logProcessor.js
+++ b/api/hooks/sdtdLogs/logProcessor.js
@@ -20,7 +20,7 @@ module.exports = async function(job) {
 
   // If latest log line is not found, get it from the server
   if (!lastLogLine) {
-    const webUIUpdate = await module.exports.getWebUIUpdates(job.data.server);
+    const webUIUpdate = await sails.helpers.sdtdApi.getWebUIUpdates(job.data.server);
     lastLogLine = parseInt(webUIUpdate.newlogs) + 1;
   }
 
@@ -29,7 +29,7 @@ module.exports = async function(job) {
     : 50;
 
   // Get new logs from the server
-  const newLogs = await module.exports.getLog(job.data.server, lastLogLine, count);
+  const newLogs = await sails.helpers.sdtdApi.getLog(job.data.server, lastLogLine, count);
 
   // Adjust latest log line based on new logs we got
   lastLogLine = lastLogLine + newLogs.entries.length;
@@ -69,6 +69,3 @@ module.exports = async function(job) {
     logs: resultLogs
   });
 };
-module.exports.getWebUIUpdates = SdtdApi.getWebUIUpdates;
-module.exports.getLog = SdtdApi.getLog;
-

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -1,3 +1,4 @@
+const SdtdApi = require("7daystodie-api-wrapper");
 /**
  * Bootstrap
  * (sails.config.bootstrap)
@@ -10,6 +11,11 @@
  */
 
 module.exports.bootstrap = async function (done) {
+  sails.helpers.sdtdApi = {};
+  for (const func of Object.keys(SdtdApi)) {
+    sails.helpers.sdtdApi[func] = SdtdApi[func];
+  }
+
   if (process.env.IS_TEST) {
     sails.cache = new Object();
     return done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,51 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@streammedev/hhmmss": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@streammedev/hhmmss/-/hhmmss-1.0.0.tgz",
@@ -3910,6 +3955,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -4155,6 +4206,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isempty": {
@@ -5437,6 +5494,30 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -10966,6 +11047,44 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "skipper": {
       "version": "0.9.0-2",
       "resolved": "https://registry.npmjs.org/skipper/-/skipper-0.9.0-2.tgz",
@@ -11693,7 +11812,7 @@
     },
     "underscore": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "nodemon": "^2.0.3",
     "nyc": "^15.0.1",
     "sails-disk": "^1.1.2",
+    "sinon": "^9.0.2",
     "supertest": "^3.3.0"
   },
   "mocha": {

--- a/test/integration/hooks/sdtdLogs/logProcessor.test.js
+++ b/test/integration/hooks/sdtdLogs/logProcessor.test.js
@@ -1,29 +1,16 @@
 const expect = require("chai").expect;
+const sinon = require('sinon');
 const logProcessor = require("../../../../api/hooks/sdtdLogs/logProcessor");
 
-const origGetWebUIUpdates = logProcessor.getWebUIUpdates;
-const origGetLog = logProcessor.getLog;
-
 describe('logProcessor', function () {
-  beforeEach(() => {
-    sails.cache = {};
-    if (!logProcessor.getWebUIUpdates) {
-      throw new Error('Fix test, function is undefined');
-    }
-    logProcessor.getWebUIUpdates = origGetWebUIUpdates;
-    if (!logProcessor.getLog) {
-      throw new Error('Fix test, function is undefined');
-    }
-    logProcessor.getLog = origGetLog;
-  });
-  it('should return an  array', async function () {
+  it('Confirm able to fetch log messages', async function () {
     sails.cache[`sdtdserver:${sails.testServer.id}:sdtdLogs:lastLogLine`] = 1100;
-    logProcessor.getWebUIUpdates = async function() {
+    sinon.stub(sails.helpers.sdtdApi, "getWebUIUpdates").callsFake(async function() {
       return {
         newlogs: 1100
       }
-    };
-    logProcessor.getLog = async function() {
+    });
+    sinon.stub(sails.helpers.sdtdApi, "getLog").callsFake(async function() {
       return {
         firstLine: 1100,
         lastLine: 1150,
@@ -46,7 +33,7 @@ describe('logProcessor', function () {
           }
         ],
       }
-    };
+    });
     const ret = await logProcessor({
       data: {
         server: {

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -1,6 +1,7 @@
 const sails = require('sails');
 const faker = require('faker');
 const MockDate = require('mockdate');
+const sinon = require('sinon')
 
 process.env.IS_TEST = true;
 process.env.NODE_ENV = 'test';
@@ -9,6 +10,15 @@ delete process.env.REDISSTRING;
 
 beforeEach(function() {
   MockDate.set('2020-05-01T01:20:05+0000');
+});
+before(() => {
+  global.sandbox = sinon.createSandbox()
+})
+beforeEach(() => {
+  global.sandbox.restore()
+})
+beforeEach(() => {
+  sails.cache = {};
 });
 // Before running any tests...
 before(function (done) {


### PR DESCRIPTION
Switch to using sinon and stubbing out function. 
* Has ability to restore after tests (in theory no test can break another test)
* Will yell if your stubbing something that doesn't exist (can detect renamed functions, but not change in prototype)
* Make a fake sails helper for 7daystodie-api-wrapper calls, so they can be stubbed out in tests

See sinon happy complain if we are stubbing the wrong thing (First was sails.helpers.sdtdapi not sails.helpers.sdtdApi, second was wrong function name)

![image](https://user-images.githubusercontent.com/110087/80909277-d0fa1c00-8cdb-11ea-8007-b65c61d856b8.png)

I so want to replace any direct calls to 7daystodie-api-wrapper but will do so when more tests are in place.
