### PR TITLE
Sentry fixes

### DIFF
--- a/api/helpers/sdtd/fill-custom-variables.js
+++ b/api/helpers/sdtd/fill-custom-variables.js
@@ -32,54 +32,9 @@ module.exports = {
 
 
   fn: async function (inputs, exits) {
-
-    let vars = findVariables(inputs.command);
-
-    for (const variableString of vars) {
-      inputs.command = replaceAllInString(inputs.command, `\${${variableString}}`, getVariableValue(variableString, inputs.data));
-    }
-
-    return exits.success(inputs.command);
-
+    return exits.success(inputs.command.toString().replace(/\$\{([^}]+)\}/g, function(match, group1, offset, wholeString) {
+      return _.get(inputs.data, group1, match);
+    }));
   }
-
 
 };
-
-function replaceAllInString(string, valueToReplace, newValue) {
-  return string.split(valueToReplace).join(newValue);
-}
-
-// Find variables denoted like ${x} and ${y} and returns an array of strings like [x, y]
-function findVariables(command) {
-  let startIdx = 0;
-  const foundVariables = [];
-
-  while (startIdx < command.length) {
-    let x = command.indexOf('${', startIdx);
-    let y = command.indexOf('}', x);
-
-    if (y !== -1 && x !== -1) {
-      // Variable found!
-      startIdx = y;
-      foundVariables.push(command.substring(x + 2, y));
-    } else {
-      // No more variables in the string, exit the loop
-      startIdx = command.length + 1;
-    }
-
-  }
-
-  return foundVariables;
-}
-
-// Input a string like "player.name" and returns the value for that (nested) property from inputs.data
-function getVariableValue(variableString, data) {
-  let propertyArray = variableString.split('.');
-  if (propertyArray.length === 1) {
-    return data[propertyArray[0]];
-  } else {
-    return getVariableValue(propertyArray.slice(1).join('.'), data[propertyArray[0]]);
-  }
-
-}

--- a/api/hooks/bannedItems/index.js
+++ b/api/hooks/bannedItems/index.js
@@ -1,3 +1,5 @@
+const Sentry = require('@sentry/node');
+
 module.exports = function banneditems(sails) {
   return {
     initialize: function(cb) {
@@ -46,33 +48,40 @@ module.exports = function banneditems(sails) {
 
   async function handleItemTrackerUpdate(data) {
     const { server, trackingInfo } = data;
-    const config = server.config[0];
+    const config = server.config[0] || {};
     const { bannedItems, bannedItemsCommand } = config;
-    const bannedItemsSet = new Set(JSON.parse(bannedItems));
 
-    for (const onlinePlayer of trackingInfo) {
-      if (onlinePlayer.inventory) {
-        if (!Array.isArray(onlinePlayer.inventory)) {
-          onlinePlayer.inventory = JSON.parse(onlinePlayer.inventory);
-        }
+    try {
+      const bannedItemsSet = new Set(JSON.parse(bannedItems));
+      for (const onlinePlayer of trackingInfo) {
+        if (onlinePlayer.inventory) {
+          if (!Array.isArray(onlinePlayer.inventory)) {
+            onlinePlayer.inventory = JSON.parse(onlinePlayer.inventory);
+          }
 
-        const playerItemsSet = new Set(onlinePlayer.inventory.map(e => e.name));
-        const unionOfSets = intersection(playerItemsSet, bannedItemsSet);
-        if (unionOfSets.size) {
-          const isImmune = await sails.helpers.roles.checkPermission.with({
-            serverId: server.id,
-            playerId: onlinePlayer.player,
-            permission: "immuneToBannedItemsList"
-          });
+          const playerItemsSet = new Set(onlinePlayer.inventory.map(e => e.name));
+          const unionOfSets = intersection(playerItemsSet, bannedItemsSet);
+          if (unionOfSets.size) {
+            const isImmune = await sails.helpers.roles.checkPermission.with({
+              serverId: server.id,
+              playerId: onlinePlayer.player,
+              permission: "immuneToBannedItemsList"
+            });
 
-          if (!isImmune.hasPermission) {
-            sails.log.info(
-              `Detected banned item(s) on player ${onlinePlayer.player} from server ${onlinePlayer.server}`
-            );
-            executePunishment(onlinePlayer.player, server, config);
+            if (!isImmune.hasPermission) {
+              sails.log.info(
+                `Detected banned item(s) on player ${onlinePlayer.player} from server ${onlinePlayer.server}`
+              );
+              executePunishment(onlinePlayer.player, server, config);
+            }
           }
         }
       }
+    } catch (e) {
+      Sentry.withScope(function(scope) {
+        scope.setTag('serverId', server.id);
+        Sentry.captureMessage(e);
+      });
     }
   }
 

--- a/api/hooks/customDiscordNotification/index.js
+++ b/api/hooks/customDiscordNotification/index.js
@@ -70,7 +70,7 @@ async function sendNotification(logLine, server, customNotif) {
 
     embed.setTitle(`Custom notification for ${server.name}`)
     .addField('Time', logLine.time, true)
-    .addField('Message', logLine.msg)
+    .addField('Message', logLine.msg.substr(0, 1024))
     .addField('Triggered by', customNotif.stringToSearchFor)
     channel.send(embed);
   }

--- a/api/hooks/discordChatBridge/chatBridgeChannel.js
+++ b/api/hooks/discordChatBridge/chatBridgeChannel.js
@@ -166,6 +166,10 @@ class ChatBridgeChannel {
   async sendRichConnectedMessageToDiscord(connectedMsg) {
     let connectedPlayer = connectedMsg.player;
 
+    if (!connectedPlayer) {
+      return;
+    }
+
     let gblBans = await BanEntry.find({
       steamId: connectedPlayer.steamId
     });

--- a/api/hooks/sentry.js
+++ b/api/hooks/sentry.js
@@ -1,0 +1,98 @@
+module.exports = function Sentry(sails) {
+  return {
+    /**
+     * Default configuration
+     *
+     * We do this in a function since the configuration key for
+     * the hook is itself configurable, so we can't just return
+     * an object.
+     */
+    defaults: {
+      __configKey__: {
+        dsn: process.env.SENTRY_DSN,
+        options: {
+          environment: process.env.NODE_ENV || 'development'
+        }
+      }
+    },
+
+    /**
+     * Initialize the hook
+     * @param  {Function} cb Callback for when we're done initializing
+     * @return {Function} cb Callback for when we're done initializing
+     */
+    initialize: function(cb) {
+      var settings = sails.config[this.configKey];
+
+      if (!settings.dsn) {
+        sails.log.verbose('DSN for Sentry is required.');
+        return cb();
+      }
+
+      const Sentry = require('@sentry/node');
+      const { getCurrentHub } = require('@sentry/core');
+      const { Severity } = require('@sentry/types');
+      const util = require('util');
+
+      Sentry.init(settings);
+
+      sails.sentry = Sentry;
+
+      const origServerError = sails.hooks.responses.middleware.serverError;
+      sails.hooks.responses.middleware.serverError = function(err) {
+        Sentry.captureException(err);
+        origServerError.bind(this)(...arguments);
+      }
+
+      for (const level of Object.keys(sails.log)) {
+        switch (level) {
+          case 'verbose':
+          case 'silly':
+          case 'blank':
+          case 'ship':
+            continue;
+
+          case 'debug':
+            sentryLevel = Severity.Debug;
+            break;
+          case 'crit':
+          case 'error':
+            sentryLevel = Severity.Error;
+            break;
+          case 'info':
+            sentryLevel = Severity.Info;
+            break;
+          case 'warn':
+            sentryLevel = Severity.Warning;
+            break;
+          default:
+            throw new Error('not sure what to do with ' + level);
+        }
+        const origFunction = sails.log[level].bind(sails.log);
+        sails.log[level] = function() {
+          getCurrentHub().addBreadcrumb(
+            {
+              category: 'sailslog',
+              level: sentryLevel,
+              message: util.format.apply(undefined, arguments),
+            },
+            {
+              input: [...arguments],
+              level,
+            },
+          );
+          origFunction(...arguments);
+        }
+      }
+
+      // handles Bluebird's promises unhandled rejections
+      process.on('unhandledRejection', function(reason) {
+        console.error('Unhandled rejection:', reason);
+        Sentry.captureException(reason);
+      });
+
+      // We're done initializing.
+      return cb();
+    }
+  };
+};

--- a/config/http.js
+++ b/config/http.js
@@ -23,10 +23,6 @@ var passport = require('passport');
 var SteamStrategy = require('passport-steam');
 var DiscordStrategy = require('passport-discord').Strategy;
 const Sentry = require('@sentry/node');
-Sentry.init({
-  dsn: process.env.SENTRY_DSN
-});
-
 
 var maxAge = 900;
 /**

--- a/config/sentry.js
+++ b/config/sentry.js
@@ -1,0 +1,7 @@
+module.exports.sentry = {
+  active: !!process.env.SENTRY_DSN,
+  dsn: process.env.SENTRY_DSN,
+  options: {
+    environment: process.env.NODE_ENV || 'development'
+  }
+};

--- a/test/integration/hooks/discordChatBridge/chatBridgeChannel.test.js
+++ b/test/integration/hooks/discordChatBridge/chatBridgeChannel.test.js
@@ -1,0 +1,17 @@
+const expect = require("chai").expect;
+const sinon = require('sinon');
+const ChatBridgeChannel = require("../../../../api/hooks/discordChatBridge/chatBridgeChannel");
+
+describe('ChatBridgeChannel', function () {
+  it('Doesnt try to do anything when non player connects', async function () {
+    sinon.stub(sails.hooks.sdtdlogs, "getLoggingObject").callsFake(async () => null);
+    sinon.stub(ChatBridgeChannel.prototype, "start").callsFake(async () => null);
+
+    const textChannel = {};
+    const cbc = new ChatBridgeChannel(textChannel, sails.testServer);
+    await cbc.sendRichConnectedMessageToDiscord({
+      player: undefined
+    });
+  });
+});
+

--- a/test/unit/helpers/sdtd/fill-custom-variables.test.js
+++ b/test/unit/helpers/sdtd/fill-custom-variables.test.js
@@ -1,0 +1,21 @@
+const chai = require('chai');
+const expect = chai.expect;
+const chaiAsPromised = require("chai-as-promised");
+
+chai.use(chaiAsPromised);
+
+describe('HELPER sdtd/fill-custom-variables', () => {
+  it('silently works when undefined data is provided', async () => {
+    const result = await sails.helpers.sdtd.fillCustomVariables('whoa there ${player.friendlyName}', {} );
+    expect(result).to.be.eql('whoa there ${player.friendlyName}');
+  });
+  it('simple replacements work', async () => {
+    const result = await sails.helpers.sdtd.fillCustomVariables('whoa there ${friendlyName}', { friendlyName: 'halkeye' } );
+    expect(result).to.be.eql('whoa there halkeye');
+  });
+  it('nested replacements work', async () => {
+    const result = await sails.helpers.sdtd.fillCustomVariables('whoa there ${player.friendlyName}', { player: { friendlyName: 'halkeye' } } );
+    expect(result).to.be.eql('whoa there halkeye');
+  });
+});
+


### PR DESCRIPTION
* Nice new sentry hook that captures 500, sails logs, and other stuff borrowed from stackoverflow
![image](https://user-images.githubusercontent.com/110087/81368440-9cec7580-90a4-11ea-9c96-213a02cbc031.png)


* [SENTRY-CSMM-2](https://sentry.io/organizations/csmm/issues/1647102543/?project=5223600&query=is%3Aunresolved) - wrap banned item tracker in try/catch so data doesnt break the service, but still log to sentry  
* [SENTRY-CSMM-R](https://sentry.io/organizations/csmm/issues/1647500115/?project=5223600&query=is%3Aunresolved&statsPeriod=14d) - Limit max message length to discord's 1024 (Discord has no constant for it)
* [SENTRY-CSMM-3](https://sentry.io/organizations/csmm/issues/1647122640/?project=5223600&query=is%3Aunresolved) - Bail early if there's no player connecting

---
Tacked on another fix

Fix [SENTRY-CSMM-5](https://sentry.io/organizations/csmm/issues/1647122640/?project=5223600&query=is%3Aunresolved) - undefined value inside of object

* Switch to using lodash _.get which handles undefined/bad paths better
* Add tests to show broken case (first one)
* Replace complex scary code with a simple replace all with function

See https://sentry.io/organizations/csmm/issues/1647122640/?project=5223600&query=is%3Aunresolved