### PR TITLE
Upgrade custom logger to allow silly and extend create table timeout

### DIFF
--- a/config/customLog.js
+++ b/config/customLog.js
@@ -1,14 +1,8 @@
 const winston = require("winston");
 
-let logLevel = process.env.CSMM_LOGLEVEL;
+const logLevel = process.env.CSMM_LOGLEVEL || 'info';
 
-if (!logLevel) {
-  logLevel = "debug";
-}
-
-if (logLevel !== "debug" && logLevel !== "info") {
-  throw new Error(`Invalid log level given, please select "debug" or "info"`);
-}
+const infoAndAbove = ['info', 'warn', 'blank', 'crit'];
 
 const transports = [
   new winston.transports.File({
@@ -25,10 +19,10 @@ const transports = [
   })
 ];
 
-if (logLevel === "debug") {
+if (!infoAndAbove.includes(logLevel)) {
   transports.push(
     new winston.transports.Console({
-      level: "debug",
+      level: logLevel,
       colorize: true,
       timestamp: true,
       humanReadableUnhandledException: true
@@ -36,7 +30,7 @@ if (logLevel === "debug") {
   );
   transports.push(
     new winston.transports.File({
-      level: "debug",
+      level: logLevel,
       name: "debuglog",
       timestamp: true,
       humanReadableUnhandledException: true,

--- a/config/log.js
+++ b/config/log.js
@@ -13,12 +13,11 @@
 // Load env vars
 require('dotenv').config();
 
-
-customLogger = require('./customLog').customLogger;
-
 module.exports.log = {
+  level: process.env.CSMM_LOGLEVEL || 'info',
+
   // Pass in our custom logger, and pass all log levels through.
-  custom: customLogger,
+  custom: require('./customLog').customLogger,
 
   //  Disable captain's log so it doesn't prefix or stringify our meta data.
   inspect: false

--- a/create_tables.js
+++ b/create_tables.js
@@ -9,11 +9,6 @@ process.env.NODE_ENV = 'development';
 
 const configOverrides = Object.assign({}, require('./config/env/production.js'), {
   hookTimeout: 60000,
-  log: {
-    level: 'error',
-    custom: null,
-    inspect: true
-  },
   hooks: {
     /* This should get shared somewhere */
     views: false,

--- a/create_tables.js
+++ b/create_tables.js
@@ -8,7 +8,7 @@ process.env.DISCORDBOTTOKEN = '';
 process.env.NODE_ENV = 'development';
 
 const configOverrides = Object.assign({}, require('./config/env/production.js'), {
-  hookTimeout: 4000,
+  hookTimeout: 60000,
   log: {
     level: 'error',
     custom: null,


### PR DESCRIPTION
Upgrade custom logger to allow silly
timeout for create table is now 60 seconds

![image](https://user-images.githubusercontent.com/110087/84098036-0a006d00-a9bb-11ea-8220-f81296d0f8cf.png)
