### PR TITLE
Refactor logic for adding queue jobs

### DIFF
--- a/api/hooks/sdtdLogs/LoggingObject.js
+++ b/api/hooks/sdtdLogs/LoggingObject.js
@@ -38,11 +38,29 @@ class LoggingObject extends EventEmitter {
     });
   }
 
+  async addFetchJob() {
+    this.queue.add(
+      {
+        serverId: this.serverId,
+        lastLogLine: this.lastLogLine // FIXME - currently ignored
+      },
+      {
+        timeout: 5000,
+        removeOnComplete: 100,
+        removeOnFail: 100,
+        attempts: 1,
+        delay: this.intervalTime
+      }
+    );
+  };
+
   async init(ms = sails.config.custom.logCheckInterval) {
 
     if (!ms) {
       ms = 3000;
     }
+
+    this.intervalTime = ms;
 
     // Make sure there are no lingering jobs
     await this.stop();
@@ -52,22 +70,8 @@ class LoggingObject extends EventEmitter {
     } catch (error) {
       // Fail silently
     }
-    const addFetchJob = async () => {
-      this.queue.add(
-        {
-          serverId: this.serverId,
-          lastLogLine: this.lastLogLine // FIXME - currently ignored
-        },
-        {
-          timeout: 10000,
-          removeOnComplete: true,
-          removeOnFail: true,
-          attempts: 1
-        }
-      );
-    };
-    this.interval = setInterval(addFetchJob, ms);
-    await addFetchJob()
+
+    await this.addFetchJob()
   }
 
   async handleError(error) {
@@ -78,6 +82,7 @@ class LoggingObject extends EventEmitter {
     // A job failed with reason `err`!
     sails.log.error(`Queue error: ${inspect(err)}`);
     await this._failedHandler();
+    await this.addFetchJob();
     return;
   }
 
@@ -123,7 +128,7 @@ class LoggingObject extends EventEmitter {
     }
 
     await this.setFailedToZero();
-    //await this.setLastLogLine();
+    await this.addFetchJob();
   }
 
   async destroy() {
@@ -171,7 +176,7 @@ class LoggingObject extends EventEmitter {
       `sdtdserver:${this.serverId}:sdtdLogs:lastSuccess`
     );
     lastSuccess = parseInt(lastSuccess);
-    if (counter > 100) {
+    if (counter > 25) {
       let prettyLastSuccess = new Date(lastSuccess);
 
       if (!this.slowmode) {


### PR DESCRIPTION
Instead of adding jobs on an interval, only add new jobs after the previous one has completed (or failed)