### PR TITLE
Add support for loki logger

### DIFF
--- a/api/winston-loki-transport.js
+++ b/api/winston-loki-transport.js
@@ -58,7 +58,6 @@ class LokiTransport extends winston.transports.Http {
             'values': [
               [
                 nanoseconds(),
-                `${options.params.message} ${JSON.stringify(options.params.meta)}`
                 `${options.params.level}: ${options.params.message}`
               ],
             ]

--- a/api/winston-loki-transport.js
+++ b/api/winston-loki-transport.js
@@ -59,7 +59,7 @@ class LokiTransport extends winston.transports.Http {
               [
                 nanoseconds(),
                 `${options.params.message} ${JSON.stringify(options.params.meta)}`
-                // `${options.params.level}: ${options.params.message}`
+                `${options.params.level}: ${options.params.message}`
               ],
             ]
           }

--- a/api/winston-loki-transport.js
+++ b/api/winston-loki-transport.js
@@ -1,0 +1,79 @@
+const winston = require('winston');
+const request = require('request');
+
+const loadNs = process.hrtime();
+const loadMs = new Date().getTime();
+
+function nanoseconds() {
+  const diffNs = process.hrtime(loadNs);
+  const part2 = BigInt(diffNs[0]) * BigInt(1e9) + BigInt(diffNs[1]);
+  return (BigInt(loadMs) * BigInt(1e6) + part2).toString();
+}
+
+function quote(str) {
+  if (!str) {
+    return str;
+  }
+  return `"${str.replace(/"/g, '"')}"`;
+}
+
+function errorToString(err) {
+  if (err.stack) {
+    return `message=${quote(err.message)},code=${quote(err.code)},stack=${quote(err.stack)}`;
+  }
+  return err.toString();
+}
+
+class LokiTransport extends winston.transports.Http {
+  constructor(options) {
+    super(options);
+    this.lokiURL = options.lokiURL;
+    this.labels = options.labels;
+    this.labels.instance = this.labels.instance.replace(/https?:\/\//g, '').replace(/\//g, '');
+  }
+
+  _request(options, callback) {
+
+    // handle errors
+    if (options.params.meta instanceof Error) {
+      options.params.message = options.params.message + errorToString(options.params.meta);
+      options.params.meta = {
+      };
+    }
+    options.params.meta.level = options.params.level;
+
+    const config = {
+      url: this.lokiURL,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        'streams': [
+          {
+            'stream': {
+              ...this.labels,
+              level: options.params.level,
+            },
+            'values': [
+              [
+                nanoseconds(),
+                `${options.params.message} ${JSON.stringify(options.params.meta)}`
+                // `${options.params.level}: ${options.params.message}`
+              ],
+            ]
+          }
+        ]
+      })
+    };
+    request(config, function (err, res, body) {
+      if (err) {
+        console.error({ err, body, config });
+      }
+      callback(err, res, body);
+    });
+  }
+}
+
+
+module.exports = LokiTransport;


### PR DESCRIPTION
So 2 options:
1) setting `CSMM_LOG_JSON=true` will make winston output to console as json, that way promtail can be setup to process it as json and stuff
2) `LOKI_URL=http://127.0.0.1:3100/loki/api/v1/push` will upload every message directly to loki (see belong screenshot)

You can do both or neither, doesn't matter. Both should mean stacktraces are grouped together.

![image](https://user-images.githubusercontent.com/110087/86559351-934e8500-bf10-11ea-9a1c-df8b511a6d46.png)

Things I've found about loki

labels are global, which is cool. `{app="csmm",level="error"}` works great. But any random per line info (eventually, like server id) is harder to support. 

Winston 3 makes it easy and straight forward to add meta data per message, but we can't make it work cleanly with sails. Essentially sails.logger.info("foo", "bar") is recorded as "foo bar" in winston 2. sails.logger.info("foo %s", "bar") is also logged as "foo bar".

In winston 3, info("foo", "bar") is recorded as "foo" with meta of "bar".
We could use the winston 3 functionality to record context, which is awesome, but we'd lose all the system logging. There are tricks to having winston 2 and winston 3 in the same install, but /shrug/

I'm bad at recording results but hoopefully this all makes sense.