### PR TITLE
Make sure we use SdtdServer.getAPIConfig when calling sdtdapi calls

### DIFF
--- a/api/controllers/Player/give-item.js
+++ b/api/controllers/Player/give-item.js
@@ -61,24 +61,14 @@ module.exports = {
         cmdToExec = `give ${player.entityId} ${inputs.itemName} ${inputs.amount} ${inputs.quality ? inputs.quality : ''}`;
       }
 
-      let response = await sails.helpers.sdtdApi.executeConsoleCommand({
-        ip: server.ip,
-        port: server.webPort,
-        adminUser: server.authName,
-        adminToken: server.authToken
-      }, cmdToExec);
+      let response = await sails.helpers.sdtdApi.executeConsoleCommand(SdtdServer.getAPIConfig(server), cmdToExec);
 
       if (response.result.startsWith('ERR:')) {
         return exits.badRequest(`Error while giving item - ${response.result}`);
       }
 
 
-      await sails.helpers.sdtdApi.executeConsoleCommand({
-        ip: server.ip,
-        port: server.webPort,
-        adminUser: server.authName,
-        adminToken: server.authToken
-      }, `pm ${player.steamId} "CSMM - You have received ${inputs.amount} of ${inputs.itemName}"`);
+      await sails.helpers.sdtdApi.executeConsoleCommand(SdtdServer.getAPIConfig(server), `pm ${player.steamId} "CSMM - You have received ${inputs.amount} of ${inputs.itemName}"`);
 
       sails.log.info(`API - Player:give-item - giving ${inputs.amount} of ${inputs.itemName} to ${inputs.playerId} with quality: ${inputs.quality}`);
       return exits.success();

--- a/api/helpers/sdtd/validate-item-name.js
+++ b/api/helpers/sdtd/validate-item-name.js
@@ -34,7 +34,7 @@ module.exports = {
     }
 
     try {
-      const itemsFound = (await sails.helpers.sdtdApi.executeConsoleCommand(server, `listitems ${inputs.itemName}`))
+      const itemsFound = (await sails.helpers.sdtdApi.executeConsoleCommand(SdtdServer.getAPIConfig(server), `listitems ${inputs.itemName}`))
         .result
         .split('\n')
         .map(itemName => itemName.trim());


### PR DESCRIPTION
since the keys between manager and api don't match up correctly

https://github.com/CatalysmsServerManager/7-days-to-die-server-manager/commit/ec4b5d5f49f2df13eb6a5ae9048b1d5957537b19

I'm honestly not sure what the best way to handle this is. Maybe mock out the fetchJson function instead, and ... nope, it takes in an object too. 

Maybe stub out fetch json, but get each function to checkServer(server) so it errors if undefined or something.