### PR TITLE
Fix #230 - lookup breaking

### DIFF
--- a/api/hooks/discordBot/commands/sdtd/lookup.js
+++ b/api/hooks/discordBot/commands/sdtd/lookup.js
@@ -90,7 +90,6 @@ class Lookup extends Commando.Command {
     foundPlayer = playerInfo[0] || foundPlayer[0];
     let lastOnlineDate = new Date(foundPlayer.lastOnline);
 
-
     let lastOnlineTimeAgo = await sails.helpers.etc.humanizedTime(lastOnlineDate);
     let embed = new this.client.customEmbed();
 

--- a/api/hooks/discordBot/commands/sdtd/lookup.js
+++ b/api/hooks/discordBot/commands/sdtd/lookup.js
@@ -87,7 +87,7 @@ class Lookup extends Commando.Command {
       serverId: sdtdServer.id,
       steamId: foundPlayer[0].steamId
     });
-    foundPlayer = playerInfo[0];
+    foundPlayer = playerInfo[0] || foundPlayer[0];
     let lastOnlineDate = new Date(foundPlayer.lastOnline);
 
 

--- a/api/hooks/discordBot/commands/sdtd/player.js
+++ b/api/hooks/discordBot/commands/sdtd/player.js
@@ -60,7 +60,8 @@ class Player extends Commando.Command {
     }
 
     let playerInfo = await sails.helpers.sdtd.loadPlayerData.with({ serverId: sdtdServer.id, steamId: foundPlayer[0].steamId });
-    foundPlayer = playerInfo[0];
+    foundPlayer = playerInfo[0] || foundPlayer[0];
+
     let lastOnlineDate = new Date(foundPlayer.lastOnline);
     let embed = new this.client.customEmbed();
 


### PR DESCRIPTION
The problem is that
https://7dtd.illy.bz/browser/binary-improvements/MapRendering/Web/API/GetPlayerList.cs#L28
returns 25 players by default. The code assumes the user will be in the
list of players. Sadly the machinepack library doesn't let you specify
more anyways. Plus I don't think it actually matters since its really
just grabbing a list of players, and it'll return the most recent 25
users.

So if someone is looking up an older user, we already know we have the
db version and its unlikely changed. So return the db version when it
cant find the return from the server.