### PR TITLE
Make create_tables.js an alias for db:migrate

### DIFF
--- a/create_tables.js
+++ b/create_tables.js
@@ -1,54 +1,10 @@
-const dotenv = require('dotenv');
-const sails = require('sails');
+const { spawn } = require('child_process');
+const npm = (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+const run = spawn(npm, ['run','db:migrate']);
 
-dotenv.config();
+run.stdout.pipe(process.stdout);
+run.stderr.pipe(process.stderr);
 
-// disable discord bot
-process.env.DISCORDBOTTOKEN = '';
-process.env.NODE_ENV = 'development';
-
-const configOverrides = Object.assign({}, require('./config/env/production.js'), {
-  hookTimeout: 60000,
-  hooks: {
-    /* This should get shared somewhere */
-    views: false,
-    sockets: false,
-    pubsub: false,
-    grunt: false,
-    http: false,
-    blueprints: false,
-    router: false,
-
-    cron: false,
-    banneditems: false,
-    customdiscordnotification: false,
-    customhooks: false,
-    discordbot: false,
-    discordchatbridge: false,
-    discordnotifications: false,
-    economy: false,
-    historicalinfo: false,
-    playertracking: false,
-    sdtdcommands: false,
-    sdtdlogs: false,
-    bullboard: false,
-    countryban: false,
-  },
-  models: {
-    // always do migrations!
-    migrate: 'alter',
-  },
-  security: {
-    csrf: false
-  },
+run.on('exit', function (code) {
+  process.exit(code);
 });
-
-sails.on('hook:orm:loaded', async () => {
-  console.log('done creating tables');
-  process.exit(0);
-});
-
-sails.load(configOverrides, function (err) {
-  if (err) { console.error(err); process.exit(1); }
-});
-


### PR DESCRIPTION
Some of the docs and scripts called create_tables.js directly, so
unti all the docs are fully upgraded, and all images are fully upgraded,
just call the npm script (which should have been the documented way
originally)