### PR TITLE
Fix logging hook not started after adding a server

### DIFF
--- a/api/controllers/SdtdServer/add-server.js
+++ b/api/controllers/SdtdServer/add-server.js
@@ -176,6 +176,8 @@ module.exports = {
         );
       }
 
+      await sails.hooks.sdtdlogs.start(addedServer.id);
+
       return exits.success(errorResponse);
     } else {
       return exits.error(errorResponse);


### PR DESCRIPTION
I think this got lost somewhere during the scaling refactorings of the logging hook. No tests because not much time and this is a big blocker for new users.