### PR TITLE
Fix top Discord command validation of argument

### DIFF
--- a/api/hooks/discordBot/commands/sdtd/top.js
+++ b/api/hooks/discordBot/commands/sdtd/top.js
@@ -13,7 +13,9 @@ class Top extends Commando.Command {
         key: 'type',
         prompt: 'Please specify which top you want to see',
         type: 'string',
-        oneOf: ['currency', 'zombies', 'players', 'deaths', 'playtime', 'score', 'level']
+        oneOf: ['currency', 'zombies', 'players', 'deaths', 'playtime', 'score', 'level'],
+        validate: (val, msg, arg) => arg.oneOf.some(valid => val === valid),
+        error: 'Top Command: Type argument value was not valid.'
       }, {
         key: 'amount',
         prompt: 'Amount of players to show',

--- a/api/hooks/discordBot/commands/sdtd/top.js
+++ b/api/hooks/discordBot/commands/sdtd/top.js
@@ -16,7 +16,7 @@ class Top extends Commando.Command {
         prompt: 'Please specify which top you want to see',
         type: 'string',
         oneOf: validTypes,
-        validate: (val, msg, arg) => arg.oneOf.some(type => val.toLowerCase() === type.toLowerCase()),
+        validate: val => validTypes.some(type => val.toLowerCase() === type.toLowerCase()),
         parse: val => val.toLowerCase(),
         error: `Top Command: Type argument value was not valid. Please use one of: ${validTypes.join(', ')}`
       }, {

--- a/api/hooks/discordBot/commands/sdtd/top.js
+++ b/api/hooks/discordBot/commands/sdtd/top.js
@@ -1,6 +1,8 @@
 const Commando = require('discord.js-commando');
 const findSdtdServer = require('../../util/findSdtdServer.js');
 
+const validTypes = ['currency', 'zombies', 'players', 'deaths', 'playtime', 'score', 'level'];
+
 class Top extends Commando.Command {
   constructor(client) {
     super(client, {
@@ -13,9 +15,10 @@ class Top extends Commando.Command {
         key: 'type',
         prompt: 'Please specify which top you want to see',
         type: 'string',
-        oneOf: ['currency', 'zombies', 'players', 'deaths', 'playtime', 'score', 'level'],
-        validate: (val, msg, arg) => arg.oneOf.some(valid => val === valid),
-        error: 'Top Command: Type argument value was not valid.'
+        oneOf: validTypes,
+        validate: (val, msg, arg) => arg.oneOf.some(type => val.toLowerCase() === type.toLowerCase()),
+        parse: val => val.toLowerCase(),
+        error: `Top Command: Type argument value was not valid. Please use one of: ${validTypes.join(', ')}`
       }, {
         key: 'amount',
         prompt: 'Amount of players to show',


### PR DESCRIPTION
Resolves #349.

Added top command validation for arguments.

Tell me if you want to bypass capitalization of argument value and to only block argument values that aren't inside **oneOf** array irrespective of their capitalization, it is just a matter of `.toLowerCase()`.

