### PR TITLE
Update funding.yml

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,1 +1,1 @@
-patreon: 1523282
+patreon: catalysm


### PR DESCRIPTION
Requires the Patreon username instead of ID
https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository