### PR TITLE
Change example docker-compose to match .env.example for port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       NODE_ENV: "production"
     env_file: .env
     ports:
-      - 127.0.0.1:8000:1337
+      - 1377:1337
     restart: unless-stopped
     entrypoint: ["npm", "run", "start:app"]
   csmm-worker:


### PR DESCRIPTION
Changes port 8000 to port 1337 to match with both the port csmm-web runs on, as well as the port in .env.example