### PR TITLE
Fix issue where null discord user throws TypeError

### DIFF
--- a/api/controllers/User/find-guilds-managed-by-user.js
+++ b/api/controllers/User/find-guilds-managed-by-user.js
@@ -42,6 +42,10 @@ module.exports = {
 
       let discordUser = discordClient.users.get(foundUser.discordId);
 
+      if (discordUser === undefined || discordUser === null) {
+        return exits.badRequest();
+      }
+
       let foundGuilds = discordClient.guilds.filter(guild => {
         let member = guild.members.get(discordUser.id);
         if (_.isUndefined(member)) {


### PR DESCRIPTION
Fix for issue #365 
Early return badRequest if the user is either undefined or null.