### PR TITLE
Fix codecoverage badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Build Status](https://codecov.io/gh/CatalysmsServerManager/7-days-to-die-server-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/CatalysmsServerManager/7-days-to-die-server-manager)
+[![Test Coverage](https://codecov.io/gh/CatalysmsServerManager/7-days-to-die-server-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/CatalysmsServerManager/7-days-to-die-server-manager)
 [![Build Status](https://travis-ci.org/CatalysmsServerManager/7-days-to-die-server-manager.svg?branch=master)](https://travis-ci.org/CatalysmsServerManager/7-days-to-die-server-manager)
 [![Discord](https://img.shields.io/discord/336821518250147850?label=Discord&logo=Discord)](http://catalysm.net/discord)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## [Documentation](https://docs.csmm.app)
 
-## [Support](https://docs.csmm.app/en/csmm/support.html)
+## [Support]
 
 We are happy to help you on our [Discord server](http://catalysm.net/discord).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align="center">
 
+[![Build Status](https://codecov.io/gh/CatalysmsServerManager/7-days-to-die-server-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/CatalysmsServerManager/7-days-to-die-server-manager)
 [![Build Status](https://travis-ci.org/CatalysmsServerManager/7-days-to-die-server-manager.svg?branch=master)](https://travis-ci.org/CatalysmsServerManager/7-days-to-die-server-manager)
 [![Discord](https://img.shields.io/discord/336821518250147850?label=Discord&logo=Discord)](http://catalysm.net/discord)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <div align="center">
 
-[![Test Coverage](https://api.codeclimate.com/v1/badges/407cdb68165fc000cfd6/test_coverage)](https://codeclimate.com/github/CatalysmsServerManager/7-days-to-die-server-manager/test_coverage)
 [![Build Status](https://travis-ci.org/CatalysmsServerManager/7-days-to-die-server-manager.svg?branch=master)](https://travis-ci.org/CatalysmsServerManager/7-days-to-die-server-manager)
 [![Discord](https://img.shields.io/discord/336821518250147850?label=Discord&logo=Discord)](http://catalysm.net/discord)
 
@@ -42,7 +41,7 @@
 
 ## [Documentation](https://docs.csmm.app)
 
-## Support
+## [Support](https://docs.csmm.app/en/csmm/support.html)
 
 We are happy to help you on our [Discord server](http://catalysm.net/discord).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## [Documentation](https://docs.csmm.app)
 
-## [Support]
+## Support
 
 We are happy to help you on our [Discord server](http://catalysm.net/discord).
 


### PR DESCRIPTION
Added new link for support which will point to the support page of CSM site and test_coverage is currently not available so removes it.