### PR TITLE
High ping kick hook should listen to the correct LoggingObject to receive events

### DIFF
--- a/api/controllers/BannedItemList/set-banned-item-status.js
+++ b/api/controllers/BannedItemList/set-banned-item-status.js
@@ -17,16 +17,16 @@ module.exports = {
 
   exits: {},
 
-  fn: async function(inputs, exits) {
+  fn: async function (inputs, exits) {
     await SdtdConfig.update(
       { server: inputs.serverId },
       { bannedItemsEnabled: inputs.status }
     );
 
     if (inputs.status) {
-      sails.hooks.banneditems.start(inputs.serverId);
+      await sails.hooks.banneditems.start(inputs.serverId);
     } else {
-      sails.hooks.banneditems.stop(inputs.serverId);
+      await sails.hooks.banneditems.stop(inputs.serverId);
     }
 
     return exits.success();

--- a/api/controllers/SdtdServer/update-connection-info.js
+++ b/api/controllers/SdtdServer/update-connection-info.js
@@ -83,7 +83,7 @@ module.exports = {
         updateObject
       );
 
-      let loggingObject = sails.hooks.sdtdlogs.getLoggingObject(
+      let loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(
         inputs.serverId
       );
 

--- a/api/helpers/meta/set-server-active.js
+++ b/api/helpers/meta/set-server-active.js
@@ -13,7 +13,7 @@ module.exports = {
 
   exits: {},
 
-  fn: async function(inputs, exits) {
+  fn: async function (inputs, exits) {
     const server = await SdtdServer.findOne(inputs.serverId).populate('config');
     if (_.isUndefined(server)) {
       return exits.error('Unknown server ID');
@@ -70,7 +70,7 @@ module.exports = {
     }
 
     if (config.bannedItemsEnabled) {
-      sails.hooks.banneditems.start(inputs.serverId);
+      await sails.hooks.banneditems.start(inputs.serverId);
     }
 
     // Historical info (aka analytics)

--- a/api/helpers/meta/set-server-inactive.js
+++ b/api/helpers/meta/set-server-inactive.js
@@ -63,7 +63,6 @@ module.exports = {
     if (config.killEarnerEnabled) {
       await sails.hooks.economy.stop(server.id, 'killEarner');
     }
-
     // High ping kick
     await sails.hooks.highpingkick.stop(server.id);
 
@@ -73,7 +72,7 @@ module.exports = {
     // SdtdCommands
     await sails.hooks.sdtdcommands.stop(server.id);
 
-    sails.hooks.banneditems.stop(server.id);
+    await sails.hooks.banneditems.stop(server.id);
 
     // Logs
     await sails.hooks.sdtdlogs.stop(server.id);

--- a/api/hooks/bannedItems/index.js
+++ b/api/hooks/bannedItems/index.js
@@ -1,7 +1,7 @@
 module.exports = function banneditems(sails) {
   return {
     initialize: function (cb) {
-      sails.on('hook:sdtdlogs:loaded', async function () {
+      sails.after('hook:sdtdlogs:loaded', async function () {
         try {
           let configs = await SdtdConfig.find({
             inactive: false
@@ -31,8 +31,8 @@ module.exports = function banneditems(sails) {
     stop: stop
   };
 
-  function start(serverId) {
-    const loggingObject = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+  async function start(serverId) {
+    const loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
 
     loggingObject.on('trackingUpdate', handleItemTrackerUpdate);
     return;

--- a/api/hooks/bannedItems/index.js
+++ b/api/hooks/bannedItems/index.js
@@ -38,8 +38,8 @@ module.exports = function banneditems(sails) {
     return;
   }
 
-  function stop(serverId) {
-    const loggingObject = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+  async function stop(serverId) {
+    const loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
     loggingObject.removeListener('trackingUpdate', handleItemTrackerUpdate);
     return;
   }

--- a/api/hooks/countryBan/index.js
+++ b/api/hooks/countryBan/index.js
@@ -327,7 +327,7 @@ module.exports = function sdtdCountryBan(sails) {
         `HOOK:countryBan Stopping countryBan for server ${serverId} `
       );
 
-      let loggingObj = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+      let loggingObj = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
 
       if (_.isUndefined(loggingObj)) {
         throw new Error('Could not find logging object for server');
@@ -483,7 +483,7 @@ module.exports = function sdtdCountryBan(sails) {
       });
       currentConfig = config.countryBanConfig;
 
-      let loggingObj = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+      let loggingObj = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
       if (_.isUndefined(loggingObj)) {
         return sails.log.error('Could not find logging object for server');
       }

--- a/api/hooks/customDiscordNotification/index.js
+++ b/api/hooks/customDiscordNotification/index.js
@@ -21,9 +21,9 @@ module.exports = function defineCustomDiscordNotificationHook(sails) {
       done();
     },
 
-    start(serverId) {
+    async start(serverId) {
 
-      let loggingObject = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+      let loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
 
       if (_.isUndefined(loggingObject)) {
         sails.log.warn(`Tried to start custom notifications for a server without a loggingObject`, {
@@ -45,8 +45,8 @@ module.exports = function defineCustomDiscordNotificationHook(sails) {
           let stringToSearchFor = notification.stringToSearchFor.toLowerCase();
 
 
-          if (logMessage.includes(stringToSearchFor) && notification.enabled ) {
-            if (notification.ignoreServerChat && (logMessage.startsWith('chat (from \'-non-player-\',') || logMessage.includes('webcommandresult_for_say')) ) {
+          if (logMessage.includes(stringToSearchFor) && notification.enabled) {
+            if (notification.ignoreServerChat && (logMessage.startsWith('chat (from \'-non-player-\',') || logMessage.includes('webcommandresult_for_say'))) {
 
             } else {
               sendNotification(logLine, server, notification);

--- a/api/hooks/customHooks/index.js
+++ b/api/hooks/customHooks/index.js
@@ -44,7 +44,7 @@ module.exports = function defineCustomHooksHook(sails) {
     },
 
     start: async function (serverId) {
-      let loggingObject = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+      let loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
 
       for (const eventType of sails.config.custom.supportedHooks) {
 

--- a/api/hooks/discordChatBridge/chatBridgeChannel.js
+++ b/api/hooks/discordChatBridge/chatBridgeChannel.js
@@ -13,9 +13,7 @@ class ChatBridgeChannel {
     this.channel = textChannel;
     this.sdtdServer = sdtdServer;
     this.config;
-    this.loggingObject = sails.hooks.sdtdlogs.getLoggingObject(
-      this.sdtdServer.id
-    );
+    this.loggingObject;
     this.donorStatus;
     this.start();
   }
@@ -29,6 +27,9 @@ class ChatBridgeChannel {
       this.donorStatus = await sails.helpers.meta.checkDonatorStatus(
         this.sdtdServer.id
       );
+
+      this.loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(this.sdtdServer.id);
+
       // Bind 'this' to sendMessage functions
       this.sendChatMessageToDiscord = this.sendChatMessageToDiscord.bind(this);
       this.sendConnectedMessageToDiscord = this.sendConnectedMessageToDiscord.bind(

--- a/api/hooks/discordChatBridge/index.js
+++ b/api/hooks/discordChatBridge/index.js
@@ -24,7 +24,7 @@ module.exports = function SdtdDiscordChatBridge(sails) {
      * @description Initializes the chatbridges(s)
      */
     initialize: async function (cb) {
-      sails.on('hook:discordbot:loaded', async function () {
+      sails.after('hook:discordbot:loaded', async function () {
         sails.log.info('Initializing custom hook (`discordChatbridge`)');
 
         let discordClient = sails.hooks.discordbot.getClient();

--- a/api/hooks/gbl/index.js
+++ b/api/hooks/gbl/index.js
@@ -35,7 +35,7 @@ async function refreshBans() {
 
   for (const server of sdtdServers) {
     try {
-      let loggingObj = sails.hooks.sdtdlogs.getLoggingObject(server.id);
+      let loggingObj = await sails.hooks.sdtdlogs.getLoggingObject(server.id);
       loggingObj.on('playerConnected', async connectedMsg => {
         if (!connectedMsg.steamID) {
           return;

--- a/api/hooks/highPingKick/index.js
+++ b/api/hooks/highPingKick/index.js
@@ -45,7 +45,7 @@ class HighPingCount {
       return;
     }
 
-    let loggingObject = this.sails.hooks.sdtdlogs.getLoggingObject(server.id);
+    let loggingObject = await this.sails.hooks.sdtdlogs.getLoggingObject(server.id);
 
     if (_.isUndefined(loggingObject)) {
       this.sails.log.warn(`Tried to start ping kicker for a server without a loggingObject - ${server.name}`, {
@@ -58,7 +58,7 @@ class HighPingCount {
   }
 
   async stop(serverId) {
-    let loggingObject = this.sails.hooks.sdtdlogs.getLoggingObject(serverId);
+    let loggingObject = await this.sails.hooks.sdtdlogs.getLoggingObject(serverId);
     loggingObject.removeListener('memUpdate', this.boundHandlePingCheck);
   }
 

--- a/api/hooks/highPingKick/index.js
+++ b/api/hooks/highPingKick/index.js
@@ -18,7 +18,7 @@ class HighPingCount {
    * @param {Function} done
    */
   initialize(done) {
-    this.sails.on('hook:orm:loaded', async () => {
+    this.sails.after('hook:sdtdlogs:loaded', async () => {
       this.sails.log.info('Initializing custom hook (`highPingKick`)');
 
       let enabledConfigs = await SdtdConfig.find({
@@ -119,7 +119,7 @@ class HighPingCount {
     }
 
     let dateEnded = new Date();
-    this.sails.log.verbose(`Performed maxPingCheck for ${server.name} - ${failedChecksForServer} / ${onlinePlayers.length} players failed the check - took ${dateEnded.valueOf() - dateStarted.valueOf()} ms`);
+    this.sails.log.debug(`Performed maxPingCheck for ${server.name} - ${failedChecksForServer} / ${onlinePlayers.length} players failed the check - took ${dateEnded.valueOf() - dateStarted.valueOf()} ms`);
   }
 
   async kickPlayer(player, server, reason) {

--- a/api/hooks/playerTracking/index.js
+++ b/api/hooks/playerTracking/index.js
@@ -21,9 +21,9 @@ module.exports = function definePlayerTrackingHook(sails) {
 
     },
 
-    start(serverId) {
+    async start(serverId) {
 
-      let loggingObject = sails.hooks.sdtdlogs.getLoggingObject(serverId);
+      let loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(serverId);
 
       if (_.isUndefined(loggingObject)) {
         sails.log.warn(`Tried to start tracking for a server without a loggingObject`, {

--- a/api/hooks/sdtdCommands/index.js
+++ b/api/hooks/sdtdCommands/index.js
@@ -130,7 +130,7 @@ module.exports = function sdtdCommands(sails) {
           await this.stop(serverId);
         }
 
-        let serverLoggingObj = sails.hooks.sdtdlogs.getLoggingObject(String(serverId));
+        let serverLoggingObj = await sails.hooks.sdtdlogs.getLoggingObject(String(serverId));
         let commandHandler = new CommandHandler(serverId, serverLoggingObj, serverConfig);
         commandInfoMap.set(String(serverId), commandHandler);
         return;

--- a/api/hooks/sdtdLogs/index.js
+++ b/api/hooks/sdtdLogs/index.js
@@ -1,5 +1,4 @@
 const LoggingObject = require('./LoggingObject');
-const EventEmitter = require('events');
 
 /**
  * @module 7dtdLoggingHook
@@ -59,8 +58,8 @@ module.exports = function sdtdLogs(sails) {
           sails.log.debug(`HOOKS - sdtdLogs - starting logging for server ${serverID}`);
           let loggingObj = await createLogObject(serverID);
           loggingInfoMap.set(serverID, loggingObj);
-          sails.hooks.playertracking.start(serverID);
-          sails.hooks.customdiscordnotification.start(serverID);
+          await sails.hooks.playertracking.start(serverID);
+          await sails.hooks.customdiscordnotification.start(serverID);
           return;
         } else {
           throw new Error(`Tried to start logging for a server that already had it enabled`);
@@ -104,11 +103,13 @@ module.exports = function sdtdLogs(sails) {
      * @method
      */
 
-    getLoggingObject: function (serverId) {
+    getLoggingObject: async function (serverId) {
       let obj = loggingInfoMap.get(String(serverId));
-
       if (_.isUndefined(obj)) {
-        return new EventEmitter();
+        // TODO: Check if server is inactive
+        sails.log.warn(`Tried to get a non-existing loggingObject, creating a new loggingObject for server ${serverId}.`);
+        await this.start(serverId);
+        obj = loggingInfoMap.get(String(serverId));
       }
       return obj;
     },

--- a/api/hooks/sdtdLogs/index.js
+++ b/api/hooks/sdtdLogs/index.js
@@ -106,10 +106,15 @@ module.exports = function sdtdLogs(sails) {
     getLoggingObject: async function (serverId) {
       let obj = loggingInfoMap.get(String(serverId));
       if (_.isUndefined(obj)) {
-        // TODO: Check if server is inactive
         sails.log.warn(`Tried to get a non-existing loggingObject, creating a new loggingObject for server ${serverId}.`);
         await this.start(serverId);
+        const config = await SdtdConfig.findOne({ where: { server: serverId } });
         obj = loggingInfoMap.get(String(serverId));
+        // If a server is set to inactive, the created loggingObject should not do anything
+        if (config.inactive) {
+          await obj.stop();
+        }
+
       }
       return obj;
     },

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -61,7 +61,7 @@ before(async function () {
 
         playerTracking: false,
         discordBot: false,
-        highpingkick: false
+        //highpingkick: false
       },
       log: { level: process.env.CSMM_LOGLEVEL || 'info' },
       security: {

--- a/test/unit/hooks/sdtdlogs/index.test.js
+++ b/test/unit/hooks/sdtdlogs/index.test.js
@@ -1,4 +1,8 @@
 const { expect } = require('chai');
+
+const LoggingObject = require('../../../../api/hooks/sdtdLogs/LoggingObject');
+
+
 describe('logging hook index', () => {
 
   it('Updates a Players country on connectedMessage event', async () => {
@@ -58,7 +62,7 @@ describe('logging hook index', () => {
       type: 'playerConnected'
     };
     await sails.hooks.sdtdlogs.start(sails.testServer.id);
-    const loggingObject = sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
+    const loggingObject = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
     sandbox.spy(Player, 'update');
     sandbox.stub(sails.hooks.discordnotifications, 'sendNotification').callsFake(() => { });
 
@@ -71,4 +75,35 @@ describe('logging hook index', () => {
     expect(Player.update.args[0][1].country).to.equal('BE');
 
   });
+
+  describe('getLoggingObject', () => {
+
+    it('Returns an instance of LoggingObject', async () => {
+      const res = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
+      // TODO: This should be an instanceof assertion but JS classes are kicking me in the brain
+      console.log(res.constructor); // => [Function: LoggingObject]
+      console.log(LoggingObject); // => [Function: LoggingObject]
+      //console.log(res.prototype.isPrototypeOf(LoggingObject)); // => Cannot read property 'isPrototypeOf' of undefined
+      expect(res instanceof LoggingObject).to.be.ok; // => Errors
+      expect(res.constructor).to.be.equal(LoggingObject);
+      expect(res).to.be.instanceOf(LoggingObject);
+    });
+
+    it('Creates a loggingObject when one doesnt exist yet', async () => {
+      await sails.hooks.sdtdlogs.stop(sails.testServer.id);
+      const res = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
+      expect(res).to.be.instanceOf(LoggingObject);
+    });
+
+    it('Returns null when a server is inactive', async () => {
+      // Could also return an inactive LoggingObject here...
+      // That will not break things in other files
+      await sails.hooks.sdtdlogs.stop(sails.testServer.id);
+      await sails.helpers.setServerInactive(sails.testServer.id);
+      const res = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
+      expect(res).to.be.null;
+    });
+
+  });
+
 });

--- a/test/unit/hooks/sdtdlogs/index.test.js
+++ b/test/unit/hooks/sdtdlogs/index.test.js
@@ -1,8 +1,5 @@
 const { expect } = require('chai');
 
-const LoggingObject = require('../../../../api/hooks/sdtdLogs/LoggingObject');
-
-
 describe('logging hook index', () => {
 
   it('Updates a Players country on connectedMessage event', async () => {
@@ -79,29 +76,28 @@ describe('logging hook index', () => {
   describe('getLoggingObject', () => {
 
     it('Returns an instance of LoggingObject', async () => {
+      // Have to require inside the test because sails does weird stuff
+      // See: https://github.com/CatalysmsServerManager/7-days-to-die-server-manager/pull/370
+      const LoggingObject = require('../../../../api/hooks/sdtdLogs/LoggingObject');
       const res = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
-      // TODO: This should be an instanceof assertion but JS classes are kicking me in the brain
-      console.log(res.constructor); // => [Function: LoggingObject]
-      console.log(LoggingObject); // => [Function: LoggingObject]
-      //console.log(res.prototype.isPrototypeOf(LoggingObject)); // => Cannot read property 'isPrototypeOf' of undefined
-      expect(res instanceof LoggingObject).to.be.ok; // => Errors
-      expect(res.constructor).to.be.equal(LoggingObject);
       expect(res).to.be.instanceOf(LoggingObject);
     });
 
     it('Creates a loggingObject when one doesnt exist yet', async () => {
+      const LoggingObject = require('../../../../api/hooks/sdtdLogs/LoggingObject');
       await sails.hooks.sdtdlogs.stop(sails.testServer.id);
       const res = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
       expect(res).to.be.instanceOf(LoggingObject);
     });
 
-    it('Returns null when a server is inactive', async () => {
-      // Could also return an inactive LoggingObject here...
-      // That will not break things in other files
-      await sails.hooks.sdtdlogs.stop(sails.testServer.id);
-      await sails.helpers.setServerInactive(sails.testServer.id);
+    it('Returns an inactive loggingObject when a server is inactive', async () => {
+      const LoggingObject = require('../../../../api/hooks/sdtdLogs/LoggingObject');
+
+      //await sails.hooks.sdtdlogs.stop(sails.testServer.id);
+      await sails.helpers.meta.setServerInactive(sails.testServer.id);
       const res = await sails.hooks.sdtdlogs.getLoggingObject(sails.testServer.id);
-      expect(res).to.be.null;
+      expect(res).to.be.instanceOf(LoggingObject);
+      expect(res.active).to.not.be.ok;
     });
 
   });


### PR DESCRIPTION
If we try to get the logging object when it doesnt exist yet, we get a vanilla event emitter that does nothing. 

Idk why I wrote this piece of code tbh, to give bugs like this a hiding place perhaps?
https://github.com/CatalysmsServerManager/7-days-to-die-server-manager/blob/master/api/hooks/sdtdLogs/index.js#L111

I vaguely remember it solved some edge case but cannot for the life of me remember why I made it like that... Should be refactored but I'm scared to break something else. For now, this should take care of the high ping kick hook