### PR TITLE
Remove upload test artifact from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,8 +54,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage/lcov.info
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: test-report
-          path: ./coverage/


### PR DESCRIPTION
This step errors so often, making the check fail while the tests actually passed. I don't think it's super useful anyway. 