### PR TITLE
Make discord bot errors link to dev discord instead of bot owners

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,6 @@ REDIS_HOST=cache
 
 DBSTRING=mysql2://csmm:mysecretpasswordissosecure@db:3306/csmm
 REDISSTRING=redis://cache:6379
+
+# Invite link for the dev server
+INVITELINK=https://catalysm.net/discord

--- a/api/hooks/discordBot/index.js
+++ b/api/hooks/discordBot/index.js
@@ -28,7 +28,8 @@ module.exports = function discordBot(sails) {
         sails.log.info('Initializing custom hook (`discordBot`)');
         client = new Commando.Client({
           owner: sails.config.custom.botOwners,
-          unknownCommandResponse: false
+          unknownCommandResponse: false,
+          invite: process.env.INVITELINK
         });
 
         sails.discordBotClient = client;


### PR DESCRIPTION
This PR aims to fix #350 

* added invite key
* included `.env` entry
* linked accordingly