### PR TITLE
Add fallback for undefined player country in Discord chatbridge rich connected messages

### DIFF
--- a/api/hooks/discordChatBridge/chatBridgeChannel.js
+++ b/api/hooks/discordChatBridge/chatBridgeChannel.js
@@ -184,7 +184,7 @@ class ChatBridgeChannel {
         `[${connectedMsg.steamId}](https://steamidfinder.com/lookup/${connectedMsg.steamId}/)`,
         true
       )
-      .addField('Country', connectedMsg.country || 'Unknown Country', true)
+      .addField('Country', connectedMsg.country || 'Unknown country', true)
       .addField(
         `${gblBans.length} ban${gblBans.length === 1 ? '' : 's'} on the global ban list`,
         `[GBL profile page](${process.env.CSMM_HOSTNAME}/gbl/profile?steamId=${connectedMsg.steamId})`

--- a/api/hooks/discordChatBridge/chatBridgeChannel.js
+++ b/api/hooks/discordChatBridge/chatBridgeChannel.js
@@ -184,7 +184,7 @@ class ChatBridgeChannel {
         `[${connectedMsg.steamId}](https://steamidfinder.com/lookup/${connectedMsg.steamId}/)`,
         true
       )
-      .addField('Country', connectedMsg.country, true)
+      .addField('Country', connectedMsg.country || 'Unknown Country', true)
       .addField(
         `${gblBans.length} ban${gblBans.length === 1 ? '' : 's'} on the global ban list`,
         `[GBL profile page](${process.env.CSMM_HOSTNAME}/gbl/profile?steamId=${connectedMsg.steamId})`


### PR DESCRIPTION
Adds a fallback value for if player's country is falsy. Fixes #356 