### PR TITLE
make sure CSMM_ADMINS is defined to avoid TypeError

### DIFF
--- a/api/hooks/discordBot/commands/meta/restart.js
+++ b/api/hooks/discordBot/commands/meta/restart.js
@@ -12,7 +12,7 @@ class Restart extends Commando.Command {
 
   async run(msg) {
 
-    const admins = process.env.CSMM_ADMINS.split(',');
+    const admins = (process.env.CSMM_ADMINS || '').split(',');
     const adminUsers = await User.find({
       where: {
         steamId: admins,

--- a/api/hooks/discordBot/commands/meta/restart.js
+++ b/api/hooks/discordBot/commands/meta/restart.js
@@ -12,7 +12,7 @@ class Restart extends Commando.Command {
 
   async run(msg) {
 
-    const admins = (process.env.CSMM_ADMINS || '').split(',');
+    const admins = sails.config.custom.adminSteamIds;
     const adminUsers = await User.find({
       where: {
         steamId: admins,


### PR DESCRIPTION
this will prevent TypeError: Cannot read property 'split' of undefined from occurring if CSMM_ADMINS is not defined #389