### PR TITLE
Reuse a single connection in redis helpers instead of requesting a new one for every operation

### DIFF
--- a/api/helpers/redis/del.js
+++ b/api/helpers/redis/del.js
@@ -23,26 +23,12 @@ module.exports = {
 
 
   fn: async function (inputs, exits) {
-
-    const datastore = sails.getDatastore('cache');
-    if (datastore.config.adapter === 'sails-redis') {
-      sails.getDatastore('cache').leaseConnection(function during(redisConnection, proceed) {
-        redisConnection.del(inputs.keyString, (err, reply) => {
-          if (err) {return proceed(err);}
-
-          return proceed(undefined, reply);
-        });
-      }).exec((err, result) => {
-        if (err) {return exits.error(err);}
-
-        return exits.success(result);
-      });
-    } else {
-      sails.cache[inputs.keyString] = null;
-      return exits.success();
-    }
-
-
-
+    const client = sails.hooks.redis.client;
+    client.del(inputs.keyString, (err, reply) => {
+      if (err) {
+        return exits.error(err);
+      }
+      return exits.success(reply);
+    });
   }
 };

--- a/api/helpers/redis/incr.js
+++ b/api/helpers/redis/incr.js
@@ -23,21 +23,12 @@ module.exports = {
 
 
   fn: async function (inputs, exits) {
-    const datastore = sails.getDatastore('cache');
-    if (datastore.config.adapter === 'sails-redis') {
-      sails.getDatastore('cache').leaseConnection(function during(redisConnection, proceed) {
-        redisConnection.incr(inputs.keyString, (err, reply) => {
-          if (err) {return proceed(err);}
-
-          return proceed(undefined, reply);
-        });
-      }).exec((err, result) => {
-        if (err) {return exits.error(err);}
-
-        return exits.success(result);
-      });
-    } else {
-      return exits.success(sails.cache[inputs.keyString]++);
-    }
+    const client = sails.hooks.redis.client;
+    client.incr(inputs.keyString, (err, reply) => {
+      if (err) {
+        return exits.error(err);
+      }
+      return exits.success(reply);
+    });
   }
 };

--- a/api/helpers/redis/set.js
+++ b/api/helpers/redis/set.js
@@ -36,44 +36,27 @@ module.exports = {
 
 
   fn: async function (inputs, exits) {
-    const datastore = sails.getDatastore('cache');
-    if (datastore.config.adapter === 'sails-redis') {
 
-      if (inputs.ex) {
-        if (_.isUndefined(inputs.ttl)) {
-          return exits.error(`When setting ex true you must provide a TTL.`);
+    const client = sails.hooks.redis.client;
+
+    if (inputs.ex) {
+      client.set(inputs.keyString, inputs.value, 'EX', inputs.ttl, (err, reply) => {
+        if (err) {
+          return exits.error(err);
         }
-
-        sails.getDatastore('cache').leaseConnection(function during(redisConnection, proceed) {
-          redisConnection.set(inputs.keyString, inputs.value, 'EX', inputs.ttl, (err, reply) => {
-            if (err) {return proceed(err);}
-
-            return proceed(undefined, reply);
-          });
-        }).exec((err, result) => {
-          if (err) {return exits.error(err);}
-
-          return exits.success(result);
-        });
-
-      } else {
-
-        sails.getDatastore('cache').leaseConnection(function during(redisConnection, proceed) {
-          redisConnection.set(inputs.keyString, inputs.value, (err, reply) => {
-            if (err) {return proceed(err);}
-
-            return proceed(undefined, reply);
-          });
-        }).exec((err, result) => {
-          if (err) {return exits.error(err);}
-
-          return exits.success(result);
-        });
-      }
+        return exits.success(reply);
+      });
     } else {
-      sails.cache[inputs.keyString] = inputs.value;
-      return exits.success();
+      client.set(inputs.keyString, inputs.value, (err, reply) => {
+        if (err) {
+          return exits.error(err);
+        }
+        return exits.success(reply);
+      });
     }
+
+
+
 
   }
 

--- a/api/hooks/redis.js
+++ b/api/hooks/redis.js
@@ -1,0 +1,29 @@
+const Sentry = require('@sentry/node');
+const redis = require('redis');
+
+/*
+ * A hook that manages the redis connection
+ * To be reused by anything that needs to talk to redis
+ * @param {*} sails
+ */
+
+module.exports = function BullBoard(sails) {
+  return {
+    /**
+     * Initialize the hook
+     * @param  {Function} cb Callback for when we're done initializing
+     * @return {Function} cb Callback for when we're done initializing
+     */
+    initialize: function (cb) {
+      this.client = redis.createClient({ url: process.env.REDISSTRING });
+
+
+      this.client.on('error', function (error) {
+        sails.log.error(error);
+        Sentry.captureException(error);
+      });
+
+      return cb();
+    }
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,6 +440,18 @@
       "requires": {
         "debug": "^2.2.0",
         "redis": "^2.1.0"
+      },
+      "dependencies": {
+        "redis": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+          "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+          "requires": {
+            "double-ended-queue": "^2.1.0-0",
+            "redis-commands": "^1.2.0",
+            "redis-parser": "^2.6.0"
+          }
+        }
       }
     },
     "@sailshq/lodash": {
@@ -457,6 +469,18 @@
         "redis": "~2.8.0",
         "socket.io-adapter": "~1.1.0",
         "uid2": "0.0.3"
+      },
+      "dependencies": {
+        "redis": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+          "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+          "requires": {
+            "double-ended-queue": "^2.1.0-0",
+            "redis-commands": "^1.2.0",
+            "redis-parser": "^2.6.0"
+          }
+        }
       }
     },
     "@sentry/apm": {
@@ -5555,6 +5579,16 @@
             "rttc": "^10.0.0-3"
           }
         },
+        "redis": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+          "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+          "requires": {
+            "double-ended-queue": "^2.1.0-0",
+            "redis-commands": "^1.2.0",
+            "redis-parser": "^2.6.0"
+          }
+        },
         "rttc": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/rttc/-/rttc-10.0.1.tgz",
@@ -7509,13 +7543,24 @@
       }
     },
     "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "redis-parser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+          "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+          "requires": {
+            "redis-errors": "^1.0.0"
+          }
+        }
       }
     },
     "redis-commands": {
@@ -9941,6 +9986,13 @@
               "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
               "requires": {
                 "lodash": "^4.17.14"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "4.17.20",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                  "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+                }
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "passport": "^0.4.1",
     "passport-discord": "^0.1.4",
     "passport-steam": "^1.0.14",
-    "redis": "^2.8.0",
+    "redis": "^3.0.2",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
     "sails": "^1.1.0",

--- a/test/unit/helpers/redis/del.test.js
+++ b/test/unit/helpers/redis/del.test.js
@@ -1,0 +1,23 @@
+const { expect } = require('chai');
+const redis = require('redis');
+
+describe('REDIS del', () => {
+
+  before(() => {
+    this.client = redis.createClient({ url: process.env.REDISSTRING });
+  });
+
+  it('Deletes a value from Redis', async () => {
+    await sails.helpers.redis.set('del-test', 'hello');
+    const response = await sails.helpers.redis.get('del-test');
+    expect(response).to.be.equal('hello');
+    await sails.helpers.redis.del('del-test');
+    const responseAfterDel = await sails.helpers.redis.get('del-test');
+
+    expect(responseAfterDel).to.be.equal(null);
+
+  });
+
+
+});
+

--- a/test/unit/helpers/redis/get.test.js
+++ b/test/unit/helpers/redis/get.test.js
@@ -1,0 +1,18 @@
+const { expect } = require('chai');
+const redis = require('redis');
+
+describe('REDIS get', () => {
+
+  before(() => {
+    this.client = redis.createClient({ url: process.env.REDISSTRING });
+  });
+
+  it('Retrieves a value from Redis', async () => {
+    this.client.set('test', 'hello');
+
+    const response = await sails.helpers.redis.get('test');
+    expect(response).to.be.equal('hello');
+
+  });
+
+});

--- a/test/unit/helpers/redis/incr.test.js
+++ b/test/unit/helpers/redis/incr.test.js
@@ -1,0 +1,17 @@
+const { expect } = require('chai');
+const redis = require('redis');
+
+describe('REDIS incr', () => {
+
+  before(() => {
+    this.client = redis.createClient({ url: process.env.REDISSTRING });
+  });
+
+  it('Increments a value from Redis', async () => {
+    await sails.helpers.redis.set('incr-test', 1);
+    await sails.helpers.redis.incr('incr-test');
+    const response = await sails.helpers.redis.get('incr-test');
+    expect(response).to.be.equal(2);
+  });
+});
+

--- a/test/unit/helpers/redis/set.test.js
+++ b/test/unit/helpers/redis/set.test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai');
+const redis = require('redis');
+
+describe('REDIS set', () => {
+
+  before(() => {
+    this.client = redis.createClient({ url: process.env.REDISSTRING });
+  });
+
+  it('Stores a value from Redis', async () => {
+    await sails.helpers.redis.set('set-test', 'hello');
+    const response = await sails.helpers.redis.get('set-test');
+    expect(response).to.be.equal('hello');
+
+  });
+
+
+  it('Stores a value from Redis with a expiry', async () => {
+    await sails.helpers.redis.set('set-test-ex', 'hello', true, 1);
+    const response = await sails.helpers.redis.get('set-test-ex');
+    expect(response).to.be.equal('hello');
+    await wait();
+    const responseAfterEx = await sails.helpers.redis.get('set-test-ex');
+    expect(responseAfterEx).to.be.equal(null);
+
+  });
+
+});
+
+async function wait() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 1000);
+  });
+}

--- a/test/unit/hooks/sdtdlogs/LoggingObject.test.js
+++ b/test/unit/hooks/sdtdlogs/LoggingObject.test.js
@@ -242,7 +242,7 @@ describe('LoggingObject', function () {
         ]
       };
       await loggingObject.handleCompletedJob(job, JSON.stringify(result));
-      expect(await sails.helpers.redis.get(`sdtdserver:${sails.testServer.id}:sdtdLogs:lastSuccess`)).to.equal('1588296005000');
+      expect(await sails.helpers.redis.get(`sdtdserver:${sails.testServer.id}:sdtdLogs:lastSuccess`)).to.equal(1588296005000);
       expect(loggingObject.lastLogLine).to.equal(10);
       expect(loggingObject.emptyResponses).to.equal(1);
     });


### PR DESCRIPTION
Use `redis` instead of using the sails redis adapter.