### PR TITLE
Create dedicated healthcheck endpoint

### DIFF
--- a/api/controllers/etc/health.js
+++ b/api/controllers/etc/health.js
@@ -1,0 +1,26 @@
+module.exports = {
+
+
+  friendlyName: 'Health',
+
+
+  description: '',
+
+
+  inputs: {},
+
+
+  exits: {
+
+  },
+
+
+  fn: async function (inputs, exits) {
+    await sails.sendNativeQuery('SELECT 1');
+
+    return exits.success();
+
+  }
+
+
+};

--- a/config/routes.js
+++ b/config/routes.js
@@ -104,6 +104,11 @@ module.exports.routes = {
     cors: false
   },
 
+  'get /health': {
+    action: 'etc/health',
+    cors: false
+  },
+
   // GBL
   'get /api/gbl/total': 'gbl.get-total-bans',
   'get /api/gbl/find': 'gbl.search-steamid',

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -9,7 +9,7 @@ const options = {
   host: 'localhost',
   port: '1337',
   timeout: 2000,
-  path: '/api/stats/'
+  path: '/health'
 };
 
 const request = http.request(options, (res) => {


### PR DESCRIPTION
This endpoint is less heavy than the stats endpoint but still does a DB query.