### PR TITLE
Increase performance for economy killEarner by parallelising promises

### DIFF
--- a/worker/processors/kill/index.js
+++ b/worker/processors/kill/index.js
@@ -8,7 +8,7 @@ const KILL_TYPE = {
   player: 'player',
 };
 
-const giveRewardsToPlayerForKill = (killCount, playerId, amountToGive, killType) => {
+const giveKillRewards = (killCount, playerId, amountToGive, killType) => {
   const promises = [];
   for (let index = 0; index < killCount; index++) {
     promises.push(
@@ -29,21 +29,19 @@ async function handleKill(killEvent) {
     return 'killEarner is disabled';
   }
 
-  if (killEvent.zombiesKilled) {
-    Promise.all(giveRewardsToPlayerForKill(
-      killEvent.zombiesKilled,
-      killEvent.id,
-      config.zombieKillReward,
-      KILL_TYPE.zombie)
-    ).catch((err) => sails.log.error(err));
-  }
+  const promisesForZombieKill = giveKillRewards(
+    killEvent.zombiesKilled,
+    killEvent.id,
+    config.zombieKillReward,
+    KILL_TYPE.zombie
+  );
 
-  if (killEvent.playersKilled) {
-    Promise.all(giveRewardsToPlayerForKill(
-      killEvent.playersKilled,
-      killEvent.id,
-      config.playerKillReward,
-      KILL_TYPE.player)
-    ).catch((err) => sails.log.error(err));
-  }
+  const promisesForPlayerKill = giveKillRewards(
+    killEvent.playersKilled,
+    killEvent.id,
+    config.playerKillReward,
+    KILL_TYPE.player
+  );
+
+  await Promise.all([...promisesForZombieKill, ...promisesForPlayerKill]);
 }

--- a/worker/processors/kill/index.js
+++ b/worker/processors/kill/index.js
@@ -3,6 +3,24 @@ module.exports = async (job) => {
   return handleKill(job.data);
 };
 
+const KILL_TYPE = {
+  zombie: 'zombie',
+  player: 'player',
+};
+
+const giveRewardsToPlayerForKill = (killCount, playerId, amountToGive, killType) => {
+  const promises = [];
+  for (let index = 0; index < killCount; index++) {
+    promises.push(
+      sails.helpers.economy.giveToPlayer.with({
+        playerId,
+        amountToGive,
+        message: `killEarner - Rewarding player for a ${killType} kill`
+      })
+    );
+  }
+  return promises;
+};
 
 async function handleKill(killEvent) {
 
@@ -12,24 +30,20 @@ async function handleKill(killEvent) {
   }
 
   if (killEvent.zombiesKilled) {
-    for (let index = 0; index < killEvent.zombiesKilled; index++) {
-      await sails.helpers.economy.giveToPlayer.with({
-        playerId: killEvent.id,
-        amountToGive: config.zombieKillReward,
-        message: `killEarner - Rewarding player for a zombie kill`
-      });
-
-    }
+    Promise.all(giveRewardsToPlayerForKill(
+      killEvent.zombiesKilled,
+      killEvent.id,
+      config.zombieKillReward,
+      KILL_TYPE.zombie)
+    ).catch((err) => sails.log.error(err));
   }
 
   if (killEvent.playersKilled) {
-    for (let index = 0; index < killEvent.playersKilled; index++) {
-      await sails.helpers.economy.giveToPlayer.with({
-        playerId: killEvent.id,
-        amountToGive: config.playerKillReward,
-        message: `killEarner - Rewarding player for a player kill`
-      });
-
-    }
+    Promise.all(giveRewardsToPlayerForKill(
+      killEvent.playersKilled,
+      killEvent.id,
+      config.playerKillReward,
+      KILL_TYPE.player)
+    ).catch((err) => sails.log.error(err));
   }
 }


### PR DESCRIPTION
Fixes #429 

Instead of using async-await within a for loop, implements `Promise.all` to parallelise the Kill Event promises.

Errors previously weren't logged, so I've added sails logging within the catch block.