### PR TITLE
Increase concurrency for tracking processor

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -86,7 +86,7 @@ sails.load(configOverrides, async function (err) {
     queues.logs.process(100, logProcessor),
     queues.discordNotifications.process(notifProcessor),
     queues.bannedItems.process(bannedItemsProcessor),
-    queues.playerTracking.process(playerTrackingProcessor),
+    queues.playerTracking.process(25, playerTrackingProcessor),
     queues.kill.process(killProcessor),
   ]);
 


### PR DESCRIPTION
Servers that don't respond fast were clogging up the queue