### PR TITLE
Use raw queries for deletion of tracking data

### DIFF
--- a/api/hooks/historicalInfo/objects/memUpdate.js
+++ b/api/hooks/historicalInfo/objects/memUpdate.js
@@ -79,6 +79,8 @@ async function clearOldInfo(server) {
       server: server.id
     });
 
+    await sails.sendNativeQuery(`DELETE FROM analytics WHERE server = $1 AND createdAt < $2;`, [server.id, borderDate.valueOf()]);
+
     let dateEnded = Date.now();
 
     sails.log.debug(`Deleted historical data of type memUpdate for server ${server.id} - took ${dateEnded - dateNow} ms`);

--- a/api/hooks/historicalInfo/objects/memUpdate.js
+++ b/api/hooks/historicalInfo/objects/memUpdate.js
@@ -72,13 +72,6 @@ async function clearOldInfo(server) {
     let dateNow = Date.now();
     let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
 
-    await Analytics.destroy({
-      createdAt: {
-        '<': borderDate.valueOf()
-      },
-      server: server.id
-    });
-
     await sails.sendNativeQuery(`DELETE FROM analytics WHERE server = $1 AND createdAt < $2;`, [server.id, borderDate.valueOf()]);
 
     let dateEnded = Date.now();

--- a/test/unit/hooks/playerTracking/playerTracking.test.js
+++ b/test/unit/hooks/playerTracking/playerTracking.test.js
@@ -95,7 +95,7 @@ describe('Player tracking', () => {
 
     await hook(sails.testServer.id);
 
-    expect(sails.sendNativeQuery).to.have.been.calledOnceWith(sinon.match(/DELETE FROM trackinginfo WHERE server = 1 AND createdAt < \d*/));
+    expect(sails.sendNativeQuery).to.have.been.calledOnceWith('DELETE FROM trackinginfo WHERE server = $1 AND createdAt < $2;', sinon.match.any);
   });
 
   describe('basicTracking', () => {

--- a/worker/processors/playerTracking/index.js
+++ b/worker/processors/playerTracking/index.js
@@ -97,9 +97,9 @@ async function deleteLocationData(server) {
   let milisecondsToKeepData = hoursToKeepData * 3600000;
   let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
 
-  const locationDeleteSQL = `DELETE FROM trackinginfo WHERE server = ${server.id} AND createdAt < ${borderDate.valueOf()};`;
+  const locationDeleteSQL = `DELETE FROM trackinginfo WHERE server = $1 AND createdAt < $2;`;
 
-  deleteResult = await sails.sendNativeQuery(locationDeleteSQL);
+  deleteResult = await sails.sendNativeQuery(locationDeleteSQL, [server.id, borderDate.valueOf()]);
 
 
   let dateEnded = new Date();


### PR DESCRIPTION
Waterline was doing a select everytime delete was called. Considering these are huge tables, those are very heavy and useless selects.