### PR TITLE
Keep more jobs around after completion/failing

### DIFF
--- a/api/helpers/get-queue-object.js
+++ b/api/helpers/get-queue-object.js
@@ -33,8 +33,8 @@ module.exports = {
         process.env.REDISSTRING,
         {
           defaultJobOptions: {
-            removeOnComplete: 100,
-            removeOnFail: 100,
+            removeOnComplete: 1000,
+            removeOnFail: 1000,
           }
         }
       );


### PR DESCRIPTION
Noticed that post-job handlers sometimes couldn't find jobs. I think it's because we keep so little finished jobs around right now, this should resolve that