### PR TITLE
Exit early and log error when hooks processor doesnt get good data

### DIFF
--- a/worker/processors/hooks/index.js
+++ b/worker/processors/hooks/index.js
@@ -1,4 +1,5 @@
 const enrichData = require('./enrichEventData');
+const Sentry = require('@sentry/node');
 
 module.exports = async (job) => {
   sails.log.debug('[Worker] Got a `hooks` job', job.data);
@@ -9,6 +10,12 @@ module.exports = async (job) => {
 async function handle(data) {
   const eventData = data.data;
   const eventType = data.type;
+
+  if (!eventData.server) {
+    sails.log.warn('Invalid data passed to hooks processor', eventData);
+    Sentry.captureMessage('Invalid data passed to hooks processor', { extra: eventData });
+    return;
+  }
 
   // First we handle any 'logLine' events.
   if (eventType === 'logLine') {


### PR DESCRIPTION
This should fix https://sentry.io/organizations/csmm/issues/2012830130/?project=5223600&query=is%3Aunresolved

Not fix the root cause but should stop Sentry getting clogged up and hopefully help debug what's going wrong