### PR TITLE
Add timeout to default job opts

### DIFF
--- a/api/helpers/get-queue-object.js
+++ b/api/helpers/get-queue-object.js
@@ -35,6 +35,7 @@ module.exports = {
           defaultJobOptions: {
             removeOnComplete: 1000,
             removeOnFail: 1000,
+            timeout: 3000
           }
         }
       );


### PR DESCRIPTION
This will force jobs that get stalled for whatever reason to exit. 
![image](https://user-images.githubusercontent.com/22315101/101277123-61d53080-37b2-11eb-8267-78cb50ad3d27.png)
