### PR TITLE
Add offset to logs job execution

### DIFF
--- a/api/hooks/sdtdLogs/LoggingObject.js
+++ b/api/hooks/sdtdLogs/LoggingObject.js
@@ -39,7 +39,7 @@ class LoggingObject extends EventEmitter {
     }
 
     if (result.logs.length) {
-      sails.log.debug(`Got ${result.length} logs for server ${this.server.id}`);
+      sails.log.debug(`Got ${result.logs.length} logs for server ${this.server.id}`);
     }
 
     for (const log of result.logs) {

--- a/worker/processors/logs/index.js
+++ b/worker/processors/logs/index.js
@@ -6,7 +6,6 @@ const FailedCounter = require('./redisVariables/failedCounter');
 
 async function waitRandomMs(min = 1, max = 100) {
   const random = Math.random() * (max - min) + min;
-  console.log(`Waiting ${random} ms`);
   return new Promise((resolve) => {
     setInterval(resolve, random);
   });

--- a/worker/processors/logs/index.js
+++ b/worker/processors/logs/index.js
@@ -70,7 +70,7 @@ module.exports = async (job) => {
    * To mitigate that, we add a small wait time to each job
    * Which will over time cause enough entropy to cause jobs to be spread out
    */
-  waitRandomMs();
+  await waitRandomMs();
 
 
   sails.log.debug('[Worker] Got a `logs` job', job.data);

--- a/worker/processors/logs/index.js
+++ b/worker/processors/logs/index.js
@@ -4,6 +4,13 @@ const LastLogLine = require('./redisVariables/lastLogLine');
 const EmptyResponses = require('./redisVariables/emptyResponses');
 const FailedCounter = require('./redisVariables/failedCounter');
 
+async function waitRandomMs(min = 1, max = 100) {
+  const random = Math.random() * (max - min) + min;
+  console.log(`Waiting ${random} ms`);
+  return new Promise((resolve) => {
+    setInterval(resolve, random);
+  });
+}
 
 async function failedHandler(job, e) {
   // Error getting logs from the server, likely a config error by the user
@@ -58,6 +65,15 @@ async function failedHandler(job, e) {
 }
 
 module.exports = async (job) => {
+  /**
+   * All servers run jobs in the same interval
+   * This means that job execution (and CPU usage) get really spikey
+   * To mitigate that, we add a small wait time to each job
+   * Which will over time cause enough entropy to cause jobs to be spread out
+   */
+  waitRandomMs();
+
+
   sails.log.debug('[Worker] Got a `logs` job', job.data);
   job.data.server = await SdtdServer.findOne(job.data.serverId);
   job.data.server.config = await SdtdConfig.findOne({ server: job.data.serverId });


### PR DESCRIPTION
So on the larger instances, CPU is super spikey with the new logging refactor.

![image](https://user-images.githubusercontent.com/22315101/101408752-284d1400-38dd-11eb-9359-59f755276ecd.png)


This PR aims to spread out job execution and thus stablize CPU usage