### PR TITLE
Fix issue in claim command after player tried to claim a bugged item

### DIFF
--- a/api/hooks/sdtdCommands/commands/claim.js
+++ b/api/hooks/sdtdCommands/commands/claim.js
@@ -70,6 +70,7 @@ class Claim extends SdtdCommand {
 
       if (response.result.includes('ERR:')) {
         sails.log.error(`Error when giving an item via the claim command! Response result: ${response.result}`);
+        delete locks[player.id];
         return chatMessage.reply('error', { error: 'Error while executing give command' });
       }
 

--- a/test/unit/hooks/commands/claim.test.js
+++ b/test/unit/hooks/commands/claim.test.js
@@ -75,5 +75,24 @@ describe('COMMAND claim', () => {
 
   });
 
+  it('Releases the lock after an error giving the items', async () => {
+    let claimedItems = await PlayerClaimItem.find({ claimed: true, player: sails.testPlayer.id });
+    expect(claimedItems.length).to.be.equal(0);
+
+    sails.helpers.sdtdApi.executeConsoleCommand.resolves({ result: 'ERR: fake error' });
+
+    await command.run(chatMessage, sails.testPlayer, sails.testServer, []);
+
+    expect(spy).to.have.been.calledWith('error');
+
+    sails.helpers.sdtdApi.executeConsoleCommand.resolves({ result: 'All good' });
+
+    await command.run(chatMessage, sails.testPlayer, sails.testServer, []);
+    expect(spy).to.not.have.been.calledWith('claimLock');
+    expect(sails.helpers.sdtdApi.executeConsoleCommand.callCount).to.be.equal(11);
+
+
+  });
+
 
 });


### PR DESCRIPTION
When a player tried to claim an item but the give command errored for whatever reason, the claim lock was not removed