### PR TITLE
Add configurable prefix to all command replies

### DIFF
--- a/api/controllers/SdtdServer/set-settings.js
+++ b/api/controllers/SdtdServer/set-settings.js
@@ -16,6 +16,10 @@ module.exports = {
     countryBanListMode: {
       type: 'boolean'
     },
+
+    replyPrefix: {
+      type: 'string'
+    }
   },
   exits: {
     badRequest: {
@@ -36,8 +40,13 @@ module.exports = {
     }
     if ('countryBanListMode' in inputs) {
       updates.countryBanListMode = inputs.countryBanListMode;
-      sails.log.info(`ServerId ${inputs.serverId} has set countryBanListMod to ${inputs.countryBanListMode}.`);
     }
+
+    if ('replyPrefix' in inputs) {
+      updates.replyPrefix = inputs.replyPrefix;
+    }
+
+    sails.log.info(`ServerId ${inputs.serverId} updated settings to ${JSON.stringify(updates)}.`);
 
     await SdtdConfig.update(
       { server: server.id },

--- a/api/hooks/sdtdCommands/commandHandler.js
+++ b/api/hooks/sdtdCommands/commandHandler.js
@@ -227,6 +227,13 @@ async function sendReplyToPlayer(server, player, type, data) {
 
 
     function sendMsg(message) {
+
+      const { replyPrefix } = server.config;
+
+      if (replyPrefix) {
+        message = `${replyPrefix} ${message}`;
+      }
+
       return sevenDays.sendMessage({
         ip: server.ip,
         port: server.webPort,

--- a/api/models/SdtdConfig.js
+++ b/api/models/SdtdConfig.js
@@ -185,6 +185,11 @@ module.exports = {
       defaultsTo: '$'
     },
 
+    replyPrefix: {
+      type: 'string',
+      defaultsTo: ''
+    },
+
     enabledCallAdmin: {
       type: 'boolean',
       defaultsTo: false

--- a/migrations/20210112215544-reply-prefix.js
+++ b/migrations/20210112215544-reply-prefix.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+      'sdtdconfig',
+      'replyPrefix',
+      {
+        type: Sequelize.DataTypes.STRING(255),
+        allowNull: true,
+        default: '',
+      }
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(
+      'sdtdconfig',
+      'replyPrefix'
+    );
+  }
+};

--- a/test/integration/controllers/set-settings.test.js
+++ b/test/integration/controllers/set-settings.test.js
@@ -1,0 +1,21 @@
+const supertest = require('supertest');
+const { expect } = require('chai');
+
+
+describe('set-settings', function () {
+  describe('Reply type', function () {
+    it('Should set the replyType', async function () {
+      const response = await supertest(sails.hooks.http.app).post('/api/sdtdserver/settings').send({ replyPrefix: 'blabla', serverId: sails.testServer.id });
+      expect(response.statusCode).to.equal(200);
+      const config = await SdtdConfig.findOne({ server: sails.testServer.id });
+      expect(config.replyPrefix).to.be.equal('blabla');
+    });
+    it('Should allow empty strings to be set', async function () {
+      const response = await supertest(sails.hooks.http.app).post('/api/sdtdserver/settings').send({ replyPrefix: '', serverId: sails.testServer.id });
+      expect(response.statusCode).to.equal(200);
+      const config = await SdtdConfig.findOne({ server: sails.testServer.id });
+      expect(config.replyPrefix).to.be.equal('');
+    });
+  });
+});
+

--- a/test/unit/hooks/commands/commandHandler.test.js
+++ b/test/unit/hooks/commands/commandHandler.test.js
@@ -1,0 +1,44 @@
+const CommandHandler = require('../../../../api/hooks/sdtdCommands/commandHandler');
+const { expect } = require('chai');
+const EventEmitter = require('events');
+
+describe('COMMAND CommandHandler', () => {
+  beforeEach(async () => {
+    this.stub = sandbox.stub(sails.helpers.sdtdApi, 'executeConsoleCommand').callsFake(async () => {
+      return {
+        result: ''
+      };
+    });
+    sails.testServerConfig = (await SdtdConfig.update(sails.testServerConfig.id, { replyPrefix: 'test' }).fetch())[0];
+    await Role.create({
+      server: sails.testServer.id,
+      name: 'Admin',
+      level: '1',
+      manageServer: true
+    });
+
+    this.emitter = new EventEmitter();
+    this.commandHandler = new CommandHandler(sails.testServer.id, this.emitter, sails.testServerConfig);
+    this.commandHandler.start();
+  });
+
+  afterEach(() => {
+    this.commandHandler.stop();
+  });
+
+  it('Respects the replyPrefix', async () => {
+    const chatMessage = {
+      messageText: `${sails.testServerConfig.commandPrefix}help`,
+      steamId: sails.testPlayer.steamId
+    };
+    await this.commandHandler.commandListener(chatMessage);
+    expect(this.stub.callCount).to.be.equal(11);
+    for (const call of this.stub.getCalls()) {
+      expect(call.lastArg).to.match(/pm \d* "test/);
+    }
+  });
+
+
+
+
+});

--- a/views/sdtdServer/partials/settings/commandSettings.sejs
+++ b/views/sdtdServer/partials/settings/commandSettings.sejs
@@ -96,7 +96,8 @@
       <input type="text" class="form-control" name="replyPrefix" id="replyPrefix" aria-describedby="replyPrefix-help"
         placeholder="">
       <small id="replyPrefix-help" class="form-text text-muted">This will be added before command replies CSMM does.
-        This is very useful for adding some colour to the messages!</small>
+        This is very useful for adding some colour to the messages! For example, a hexcode like [02f9dd] will turn
+        everything blue</small>
     </div>
 
     <button id="replyPrefix-btn" class="btn btn-primary">Save prefix</button>

--- a/views/sdtdServer/partials/settings/commandSettings.sejs
+++ b/views/sdtdServer/partials/settings/commandSettings.sejs
@@ -89,6 +89,18 @@
   <div id="replySettings">
     <hr>
     <%- await include('./commandReplies.sejs') %>
+
+
+    <div class="form-group">
+      <label for="replyPrefix">Reply prefix</label>
+      <input type="text" class="form-control" name="replyPrefix" id="replyPrefix" aria-describedby="replyPrefix-help"
+        placeholder="">
+      <small id="replyPrefix-help" class="form-text text-muted">This will be added before command replies CSMM does.
+        This is very useful for adding some colour to the messages!</small>
+    </div>
+
+    <button id="replyPrefix-btn" class="btn btn-primary">Save prefix</button>
+
   </div>
 
 
@@ -142,7 +154,7 @@
     </thead>
     <tbody>
 
-    <% for(let command of customCommands){%>
+      <% for(let command of customCommands){%>
 
       <tr>
         <td scope="row"><%= command.name %></td>
@@ -162,56 +174,56 @@
 
   <%- await include('./addCommandModal.sejs') %>
 
-  <!-- Button trigger modal -->
-  <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#custom-commands-import-modal">
-    Import
-  </button>
+      <!-- Button trigger modal -->
+      <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#custom-commands-import-modal">
+        Import
+      </button>
 
-  <!-- Modal -->
-  <div class="modal fade" id="custom-commands-import-modal" tabindex="-1" role="dialog"
-    aria-labelledby="custom-commands-import-modal-title" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" id="custom-commands-import-modal-title">Import</h4>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="container-fluid">
-
-            <div class="alert alert-warning" role="alert">
-              Importing custom commands is an advanced function. Check the documentation for more info.
-              <br> This will delete the current custom commands you have. Make sure to include them in your import
-              statement.
-              Command arguments are currently not supported to be imported!
+      <!-- Modal -->
+      <div class="modal fade" id="custom-commands-import-modal" tabindex="-1" role="dialog"
+        aria-labelledby="custom-commands-import-modal-title" aria-hidden="true">
+        <div class="modal-dialog modal-lg" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title" id="custom-commands-import-modal-title">Import</h4>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
             </div>
+            <div class="modal-body">
+              <div class="container-fluid">
 
-            <div class="form-group">
-              <label for="custom-commands-import-json">Custom commands JSON</label>
-              <textarea class="form-control" name="custom-commands-import-json" id="custom-commands-import-json"
-                rows="10"></textarea>
+                <div class="alert alert-warning" role="alert">
+                  Importing custom commands is an advanced function. Check the documentation for more info.
+                  <br> This will delete the current custom commands you have. Make sure to include them in your import
+                  statement.
+                  Command arguments are currently not supported to be imported!
+                </div>
+
+                <div class="form-group">
+                  <label for="custom-commands-import-json">Custom commands JSON</label>
+                  <textarea class="form-control" name="custom-commands-import-json" id="custom-commands-import-json"
+                    rows="10"></textarea>
+                </div>
+
+                <div id="custom-commands-import-problems" class="alert alert-warning invisible" role="alert">
+
+                </div>
+
+              </div>
             </div>
-
-            <div id="custom-commands-import-problems" class="alert alert-warning invisible" role="alert">
-
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button id="custom-commands-import-btn" type="button" class="btn btn-primary">Import</button>
             </div>
-
           </div>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <button id="custom-commands-import-btn" type="button" class="btn btn-primary">Import</button>
-        </div>
       </div>
-    </div>
-  </div>
 
-  <a name="export-customcommands" id="export-custom-commands" class="btn btn-secondary"
-    href="/api/sdtdserver/commands/export?serverId=<%= server.id %>" role="button">Export to file</a>
+      <a name="export-customcommands" id="export-custom-commands" class="btn btn-secondary"
+        href="/api/sdtdserver/commands/export?serverId=<%= server.id %>" role="button">Export to file</a>
 
-  <%- await include('../commandsHelpButton.sejs') %>
+      <%- await include('../commandsHelpButton.sejs') %>
 
 </div>
 
@@ -441,7 +453,7 @@
             _csrf: window.SAILS_LOCALS._csrf,
             serverId: window.SAILS_LOCALS.server.id,
           },
-          success: data => {},
+          success: data => { },
           error: function (xhr, status, error) {
             displayAjaxToSupportData(xhr, this);;
             showErrorModal(`${error} - ${xhr.responseText}`, xhr);
@@ -467,8 +479,8 @@
       e.preventDefault();
       let newMax = $('#inputs-settings-commands-playerteleports-maxlocations').val();
       if (!validator.isInt(newMax, {
-          min: 1
-        })) {
+        min: 1
+      })) {
         return showErrorModal('Please provide a valid value for max locations.')
       }
 
@@ -491,8 +503,8 @@
       e.preventDefault();
       let newTimeout = $('#inputs-settings-commands-playerteleports-timeout').val();
       if (!validator.isInt(newTimeout, {
-          min: 3
-        })) {
+        min: 3
+      })) {
         return showErrorModal('Please provide a valid value for timeout. (number larger than 3)')
       }
 
@@ -516,8 +528,8 @@
       let newDelay = $('#inputs-settings-commands-playerteleports-delay').val();
 
       if (!validator.isInt(newDelay, {
-          min: 0
-        })) {
+        min: 0
+      })) {
         return showErrorModal('Please provide a valid value for delay. (number larger than 0)')
       }
 
@@ -536,7 +548,28 @@
       })
     })
 
+    $("#replyPrefix").val(window.SAILS_LOCALS.config.replyPrefix);
 
+
+    $("#replyPrefix-btn").click(e => {
+      let replyPrefix = $("#replyPrefix").val();
+      $.ajax({
+        url: `/api/sdtdserver/settings`,
+        type: 'POST',
+        data: {
+          _csrf: window.SAILS_LOCALS._csrf,
+          serverId: window.SAILS_LOCALS.server.id,
+          replyPrefix: replyPrefix
+        },
+        success: (data, status, xhr) => {
+
+        },
+        error: function (xhr, status, error) {
+          displayAjaxToSupportData(xhr, this);;
+          showErrorModal(`${error} - ${xhr.responseText}`, xhr);
+        }
+      });
+    })
 
   })
 


### PR DESCRIPTION
This allows all CSMM replies to get a colour via CPM. A hex code like `[02f9dd]` will make everything cyan for example

![Peek 2021-01-12 23-22](https://user-images.githubusercontent.com/22315101/104381984-a7adb300-552d-11eb-9ba0-5c6a434cc3bb.gif)
