### PR TITLE
Remove check run reporter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,11 +55,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./reports/coverage/lcov.info
-      - uses: check-run-reporter/action@v2.0.0
-        # always run, otherwise you'll only see results for passing builds
-        if: ${{ always() }}
-        with:
-          # Token in plaintext to allow CRR to run for forked PRs
-          # https://github.com/check-run-reporter/feedback/issues/9
-          token: "01d31e48-772c-4bcb-b5fa-239689ad5419"
-          report: "reports/**/*.xml"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint": "eslint --max-warnings 0 .",
     "dev": "cross-env NODE_ENV=development nodemon --exec concurrently --kill-others -n 'app,worker' 'npm run start:app' 'npm run start:worker'",
     "debug": "node debug app.js",
-    "cover": "nyc npm run test -- --reporter mocha-junit-reporter ",
+    "cover": "nyc npm run test",
     "itemIcons:update": "bash ./scripts/itemIconsUpdate.sh",
     "postversion": "git push && git push --tags",
     "sequelize": "sequelize-cli",


### PR DESCRIPTION
This thing is great if your PR has code changes. When it's just dependencies, you cannot see what went wrong. Also, log output is a lot more detailed than what CRR produced.