### PR TITLE
Refactor Discord client to be used in both processes

### DIFF
--- a/api/controllers/SdtdServer/discordBot/check-if-bot-is-in-guild.js
+++ b/api/controllers/SdtdServer/discordBot/check-if-bot-is-in-guild.js
@@ -33,7 +33,7 @@ module.exports = {
     sails.log.debug(`API - SdtdServer:check-if-bot-is-in-guild - Check if the bot is in server ${inputs.guildId}!`);
     try {
 
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
 
       exits.success(discordClient.guilds.cache.has(inputs.guildId));
 

--- a/api/controllers/SdtdServer/discordBot/find-channel-by-id.js
+++ b/api/controllers/SdtdServer/discordBot/find-channel-by-id.js
@@ -30,7 +30,7 @@ module.exports = {
   fn: async function (inputs, exits) {
     try {
 
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
 
       let foundChannel = await discordClient.channels.cache.get(inputs.channelId);
 

--- a/api/controllers/SdtdServer/discordBot/find-writeable-channels-in-guild.js
+++ b/api/controllers/SdtdServer/discordBot/find-writeable-channels-in-guild.js
@@ -33,7 +33,7 @@ module.exports = {
 
     try {
 
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
       let guild = discordClient.guilds.cache.get(inputs.guildId);
       if (_.isUndefined(guild)) {
         return exits.success([]);

--- a/api/controllers/SdtdServer/discordBot/get-server-roles.js
+++ b/api/controllers/SdtdServer/discordBot/get-server-roles.js
@@ -27,7 +27,7 @@ module.exports = {
 
     let foundRoles = new Array();
     if (server.config[0].discordGuildId) {
-      let discordClient = await sails.hooks.discordbot.getClient();
+      let discordClient = await sails.helpers.discord.getClient();
       let discordGuild = await discordClient.guilds.fetch(server.config[0].discordGuildId);
       if (!_.isUndefined(discordGuild)) {
         foundRoles = discordGuild.roles.cache.array();

--- a/api/controllers/SdtdServer/discordBot/set-chat-channel.js
+++ b/api/controllers/SdtdServer/discordBot/set-chat-channel.js
@@ -38,7 +38,7 @@ module.exports = {
 
     try {
       let server = await SdtdServer.findOne(inputs.serverId);
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
       let chatChannel = await discordClient.channels.cache.get(inputs.chatChannelId);
       let chatBridgeHook = sails.hooks.discordchatbridge;
 

--- a/api/controllers/SdtdServer/discordBot/set-discord-guild.js
+++ b/api/controllers/SdtdServer/discordBot/set-discord-guild.js
@@ -30,7 +30,7 @@ module.exports = {
 
     try {
       let server = await SdtdServer.findOne(inputs.serverId);
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
       let chatBridgeHook = sails.hooks.discordchatbridge;
 
       if (inputs.discordGuildId === '0') {

--- a/api/controllers/SdtdServer/discordBot/set-notification-channel.js
+++ b/api/controllers/SdtdServer/discordBot/set-notification-channel.js
@@ -34,7 +34,7 @@ module.exports = {
 
     try {
       let server = await SdtdServer.findOne(inputs.serverId);
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
       let notificationChannel = await discordClient.channels.cache.get(inputs.notificationChannelId);
 
       if (_.isUndefined(server)) {

--- a/api/controllers/SdtdServer/discordBot/set-prefix.js
+++ b/api/controllers/SdtdServer/discordBot/set-prefix.js
@@ -25,7 +25,7 @@ module.exports = {
   fn: async function (inputs, exits) {
 
     await SdtdConfig.update({ server: inputs.serverId }, { discordPrefix: inputs.prefix });
-    let discordClient = sails.hooks.discordbot.getClient();
+    let discordClient = sails.helpers.discord.getClient();
     let guild = discordClient.guilds.cache.get(inputs.guildId);
     if (guild) {
       guild.commandPrefix = inputs.prefix;

--- a/api/controllers/User/find-guilds-managed-by-user.js
+++ b/api/controllers/User/find-guilds-managed-by-user.js
@@ -33,7 +33,7 @@ module.exports = {
 
     try {
 
-      const discordClient = sails.hooks.discordbot.getClient();
+      const discordClient = sails.helpers.discord.getClient();
       const foundUser = await User.findOne(inputs.userId);
 
       if (_.isUndefined(foundUser) || '' === foundUser.discordId) {

--- a/api/helpers/discord/get-client.js
+++ b/api/helpers/discord/get-client.js
@@ -1,0 +1,29 @@
+const Commando = require('discord.js-commando');
+
+let client;
+
+module.exports = {
+    friendlyName: 'Get Discord client',
+    inputs: {
+    },
+
+    exits: {},
+
+    sync: true,
+
+    fn: function (inputs, exits) {
+
+        if (client) {
+            return exits.success(client);
+        }
+
+        client = new Commando.Client({
+            owner: sails.config.custom.botOwners,
+            unknownCommandResponse: false,
+            invite: process.env.INVITELINK
+        });
+
+        return exits.success(client);
+    },
+};
+

--- a/api/helpers/discord/get-client.js
+++ b/api/helpers/discord/get-client.js
@@ -3,27 +3,27 @@ const Commando = require('discord.js-commando');
 let client;
 
 module.exports = {
-    friendlyName: 'Get Discord client',
-    inputs: {
-    },
+  friendlyName: 'Get Discord client',
+  inputs: {
+  },
 
-    exits: {},
+  exits: {},
 
-    sync: true,
+  sync: true,
 
-    fn: function (inputs, exits) {
+  fn: function (inputs, exits) {
 
-        if (client) {
-            return exits.success(client);
-        }
+    if (client) {
+      return exits.success(client);
+    }
 
-        client = new Commando.Client({
-            owner: sails.config.custom.botOwners,
-            unknownCommandResponse: false,
-            invite: process.env.INVITELINK
-        });
+    client = new Commando.Client({
+      owner: sails.config.custom.botOwners,
+      unknownCommandResponse: false,
+      invite: process.env.INVITELINK
+    });
 
-        return exits.success(client);
-    },
+    return exits.success(client);
+  },
 };
 

--- a/api/helpers/meta/get-donator-status.js
+++ b/api/helpers/meta/get-donator-status.js
@@ -34,7 +34,7 @@ module.exports = {
         break;
     }
 
-    let discordClient = sails.hooks.discordbot.getClient();
+    let discordClient = sails.helpers.discord.getClient();
     let developerGuild = discordClient.guilds.cache.get(
       sails.config.custom.donorConfig.devDiscordServer
     );

--- a/api/helpers/meta/load-system-stats-and-info.js
+++ b/api/helpers/meta/load-system-stats-and-info.js
@@ -21,7 +21,7 @@ module.exports = {
 
   fn: async function (inputs, exits) {
 
-    let discordClient = sails.hooks.discordbot.getClient();
+    let discordClient = sails.helpers.discord.getClient();
     let amountOfDiscordGuilds = discordClient.guilds.cache.size;
     let amountOfOnlineDiscordUsers = discordClient.users.cache.size;
 

--- a/api/hooks/customDiscordNotification/index.js
+++ b/api/hooks/customDiscordNotification/index.js
@@ -62,7 +62,7 @@ module.exports = function defineCustomDiscordNotificationHook(sails) {
 
 async function sendNotification(logLine, server, customNotif) {
 
-  let discordClient = sails.hooks.discordbot.getClient();
+  let discordClient = sails.helpers.discord.getClient();
   let channel = await discordClient.channels.cache.get(customNotif.discordChannelId);
 
   if (!_.isUndefined(channel)) {

--- a/api/hooks/discordBot/index.js
+++ b/api/hooks/discordBot/index.js
@@ -1,4 +1,3 @@
-const Commando = require('discord.js-commando');
 const path = require('path');
 const { handleRoleUpdate } = require('./roles/handleRoleUpdate.js');
 
@@ -26,11 +25,7 @@ module.exports = function discordBot(sails) {
     initialize: function (cb) {
       sails.on('hook:sdtdlogs:loaded', function () {
         sails.log.info('Initializing custom hook (`discordBot`)');
-        client = new Commando.Client({
-          owner: sails.config.custom.botOwners,
-          unknownCommandResponse: false,
-          invite: process.env.INVITELINK
-        });
+        client = sails.helpers.discord.getClient();
 
         sails.discordBotClient = client;
         // eslint-disable-next-line callback-return
@@ -143,17 +138,6 @@ module.exports = function discordBot(sails) {
           sails.log.warn(`No Discord bot token was given, not logging in. This is probably not what you wanted!`);
         }
       });
-    },
-
-    /**
-     * @memberof module:DiscordBot
-     * @method
-     * @name getClient
-     * @description returns the discord client
-     */
-
-    getClient: function () {
-      return sails.discordBotClient;
     },
   };
 

--- a/api/hooks/discordChatBridge/index.js
+++ b/api/hooks/discordChatBridge/index.js
@@ -27,7 +27,7 @@ module.exports = function SdtdDiscordChatBridge(sails) {
       sails.after('hook:discordbot:loaded', async function () {
         sails.log.info('Initializing custom hook (`discordChatbridge`)');
 
-        let discordClient = sails.hooks.discordbot.getClient();
+        let discordClient = sails.helpers.discord.getClient();
 
         discordClient.on('ready', async () => {
           try {
@@ -101,7 +101,7 @@ module.exports = function SdtdDiscordChatBridge(sails) {
 
     try {
       sails.log.debug(`HOOK SdtdDiscordChatBridge:start - Starting chatbridge for server ${serverId}`);
-      let discordClient = sails.hooks.discordbot.getClient();
+      let discordClient = sails.helpers.discord.getClient();
       let config = await SdtdConfig.find({
         server: serverId
       }).limit(1);

--- a/api/hooks/economy/objects/discordMessageHandler.js
+++ b/api/hooks/economy/objects/discordMessageHandler.js
@@ -8,8 +8,8 @@ class DiscordMessageHandler {
   }
 
   async init() {
-    let client = sails.hooks.discordbot.getClient();
-    let emitterObj =  new GuildMessageEmitter();
+    let client = sails.helpers.discord.getClient();
+    let emitterObj = new GuildMessageEmitter();
     this.emitter = emitterObj;
 
 

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -36,7 +36,7 @@ module.exports.bootstrap = async function (done) {
     {
       attempts: 1,
       repeat: {
-        cron: '0 0 * * *',
+        cron: '* * * * *',
       }
     });
 

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -36,7 +36,7 @@ module.exports.bootstrap = async function (done) {
     {
       attempts: 1,
       repeat: {
-        cron: '* * * * *',
+        cron: '0 0 * * *',
       }
     });
 

--- a/test/integration/controllers/setChatChannel.test.js
+++ b/test/integration/controllers/setChatChannel.test.js
@@ -4,14 +4,14 @@ const { expect } = require('chai');
 describe('/api/sdtdserver/setchatchannel', function () {
 
   beforeEach(() => {
-    const client = sails.hooks.discordbot.getClient();
+    const client = sails.helpers.discord.getClient();
     sandbox.stub(client.channels.cache, 'get').returns({ send: sandbox.stub() });
     sandbox.stub(sails.hooks.discordchatbridge, 'start').returns(null);
     sandbox.stub(sails.hooks.discordchatbridge, 'stop').returns(null);
   });
 
   it('returns OK with correct data', async function () {
-    const client = sails.hooks.discordbot.getClient();
+    const client = sails.helpers.discord.getClient();
     sandbox.stub(sails.hooks.discordchatbridge, 'getStatus').returns(false);
     const response = await supertest(sails.hooks.http.app)
       .post('/api/sdtdserver/setchatchannel')

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -59,6 +59,11 @@ sails.load(configOverrides, async function (err) {
     scope.setTag('workerProcess', process.env.npm_lifecycle_event || 'worker');
   });
 
+  const discordClient = sails.helpers.discord.getClient();
+  if (process.env.DISCORDBOTTOKEN) {
+    await discordClient.login(sails.config.custom.botToken);
+  }
+
   const queues = {
     logs: sails.helpers.getQueueObject('logs'),
     discordNotifications: sails.helpers.getQueueObject('discordNotifications'),


### PR DESCRIPTION
By changing the Discord client initialization logic like this, we can use the client without problems in the worker process.
In the worker, the client gets no listeners, no registered commands, etc. This essentially makes it an advanced REST client