### PR TITLE
Fix a bad logging call in bannedItems hook

### DIFF
--- a/worker/processors/bannedItems/handleTrackingUpdate.js
+++ b/worker/processors/bannedItems/handleTrackingUpdate.js
@@ -15,7 +15,7 @@ module.exports = async function handleItemTrackerUpdate(data) {
     try {
 
       if (!onlinePlayer.inventory) {
-        sails.log.warning('HOOK:bannedItems - onlinePlayer does not have inventory property', onlinePlayer);
+        sails.log.warn('HOOK:bannedItems - onlinePlayer does not have inventory property', onlinePlayer);
         continue;
       }
 


### PR DESCRIPTION
This would trip up bannedItems sometimes. Shouldn't happen very often, this was a log line when the player data was in a weird state