### PR TITLE
Work around Allocs returning stale data when a hook fires

### DIFF
--- a/test/unit/helpers/sdtd/loadPlayerStats.test.js
+++ b/test/unit/helpers/sdtd/loadPlayerStats.test.js
@@ -1,0 +1,88 @@
+const chai = require('chai');
+const expect = chai.expect;
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+
+describe('HELPER load player stats', () => {
+
+  beforeEach(async () => {
+    await Player.create({ ...sails.testPlayer, steamId: '1', id: 4656 });
+    const getOnlinePlayersResponse = [
+      {
+        'steamid': '1',
+        'entityid': 171,
+        'ip': '192.168.13.37',
+        'name': 'Catalysm',
+        'online': true,
+        'position': { 'x': 1506, 'y': 62, 'z': 173 },
+        'experience': -1,
+        'level': 18.0453910827637,
+        'health': 29,
+        'stamina': 72.1149978637695,
+        'zombiekills': 378,
+        'playerkills': 0,
+        'playerdeaths': 19,
+        'score': 82,
+        'totalplaytime': 116473,
+        'lastonline': '2021-03-15T21:14:01',
+        'ping': 10
+      },
+      {
+        'steamid': sails.testPlayer.steamId,
+        'entityid': sails.testPlayer.entityId,
+        'ip': '192.168.13.37',
+        'name': sails.testPlayer.name,
+        'online': true,
+        'position': { 'x': 1506, 'y': 62, 'z': 173 },
+        'experience': -1,
+        'level': 18.0453910827637,
+        'health': 29,
+        'stamina': 72.1149978637695,
+        'zombiekills': 378,
+        'playerkills': 0,
+        'playerdeaths': 19,
+        'score': 82,
+        'totalplaytime': 116473,
+        'lastonline': '2021-03-15T21:14:01',
+        'ping': 10
+      }
+    ];
+    sandbox.stub(sails.helpers.sdtdApi, 'getOnlinePlayers').resolves(getOnlinePlayersResponse);
+  });
+
+  it('returns a list of players', async () => {
+    const response = await sails.helpers.sdtd.loadPlayerStats(sails.testServer.id);
+    expect(response).to.be.a('array');
+    expect(response).to.have.length(2);
+    expect(response[0].steamId).to.be.equal('1');
+  });
+
+  it('Filters on steam ID', async () => {
+    const response = await sails.helpers.sdtd.loadPlayerStats(sails.testServer.id, sails.testPlayer.steamId);
+    expect(response).to.be.a('object');
+    expect(response.steamId).to.be.equal(sails.testPlayer.steamId);
+  });
+
+  it('Updates records in the database', async () => {
+    const origPlayer = await Player.findOne(sails.testPlayer.id);
+    expect(origPlayer.deaths).to.be.equal(0);
+    expect(origPlayer.score).to.be.equal(0);
+    expect(origPlayer.level).to.be.equal(0);
+    expect(origPlayer.positionX).to.be.equal(0);
+    expect(origPlayer.positionY).to.be.equal(0);
+    expect(origPlayer.positionZ).to.be.equal(0);
+    const response = await sails.helpers.sdtd.loadPlayerStats(sails.testServer.id);
+    expect(response).to.be.a('array');
+    expect(response).to.have.length(2);
+    expect(response[0].steamId).to.be.equal('1');
+    const resultPlayer = await Player.findOne(sails.testPlayer.id);
+    expect(resultPlayer.deaths).to.be.equal(19);
+    expect(resultPlayer.score).to.be.equal(82);
+    expect(resultPlayer.level).to.be.equal(18);
+    expect(resultPlayer.positionX).to.be.equal(1506);
+    expect(resultPlayer.positionY).to.be.equal(62);
+    expect(resultPlayer.positionZ).to.be.equal(173);
+  });
+
+});

--- a/worker/processors/hooks/enrichEventData.js
+++ b/worker/processors/hooks/enrichEventData.js
@@ -57,10 +57,14 @@ module.exports = async function enrichEventData(event) {
       });
     }
   }
-  newData.player = (await sails.helpers.sdtd.loadPlayerData.with({
-    serverId: event.server.id,
-    steamId: player.steamId
-  }))[0];
+
+  if (player) {
+    newData.player = (await sails.helpers.sdtd.loadPlayerData.with({
+      serverId: event.server.id,
+      steamId: player.steamId
+    }))[0];
+  }
+
   return newData;
 
 };

--- a/worker/processors/hooks/enrichEventData.js
+++ b/worker/processors/hooks/enrichEventData.js
@@ -35,19 +35,17 @@ module.exports = async function enrichEventData(event) {
   }
 
   if (!_.isEmpty(event.steamId)) {
-    player = await sails.helpers.sdtd.loadPlayerData.with({
-      serverId: event.server.id,
-      steamId: event.steamId
+    player = await Player.findOne({
+      steamId: event.steamId,
+      server: event.server.id
     });
-    player = player[0];
   }
 
   if (!_.isEmpty(event.steamID)) {
-    player = await sails.helpers.sdtd.loadPlayerData.with({
-      serverId: event.server.id,
-      steamId: event.steamID
+    player = await Player.findOne({
+      steamId: event.steamID,
+      server: event.server.id
     });
-    player = player[0];
   }
 
   // If we do not find the player via steamId, we try via name.
@@ -59,7 +57,10 @@ module.exports = async function enrichEventData(event) {
       });
     }
   }
-  newData.player = player;
+  newData.player = (await sails.helpers.sdtd.loadPlayerData.with({
+    serverId: event.server.id,
+    steamId: player.steamId
+  }))[0];
   return newData;
 
 };

--- a/worker/processors/hooks/index.js
+++ b/worker/processors/hooks/index.js
@@ -66,7 +66,7 @@ async function executeHook(eventData, hookToExec, serverId, eventType = 'logLine
   // Ugly hack to work around some data inconsistency
   // When a hook fires, Allocs hasnt always updated internal data yet
   // So API requests get stale data back
-  if (eventType === 'playerLevel') {
+  if (eventType === 'playerLevel' && eventData.player) {
     eventData.player.level = eventData.newLvl;
   }
 

--- a/worker/processors/hooks/index.js
+++ b/worker/processors/hooks/index.js
@@ -50,7 +50,7 @@ async function handle({ data: eventData, type: eventType, server }) {
       if (isNotOnCooldown) {
         const variables = await getHookVariables(hookToExec.id);
         hookToExec.variables = variables;
-        await executeHook(eventData, hookToExec, server.id);
+        await executeHook(eventData, hookToExec, server.id, eventType);
       }
     }
   }
@@ -58,10 +58,18 @@ async function handle({ data: eventData, type: eventType, server }) {
 
 
 
-async function executeHook(eventData, hookToExec, serverId) {
+async function executeHook(eventData, hookToExec, serverId, eventType = 'logLine') {
   let server = await SdtdServer.findOne(serverId);
   eventData.server = server;
   eventData = await enrichData(eventData);
+
+  // Ugly hack to work around some data inconsistency
+  // When a hook fires, Allocs hasnt always updated internal data yet
+  // So API requests get stale data back
+  if (eventType === 'playerLevel') {
+    eventData.player.level = eventData.newLvl;
+  }
+
   eventData.custom = getVariablesValues(hookToExec.variables, eventData.msg);
   let results = await sails.helpers.sdtd.executeCustomCmd(server, hookToExec.commandsToExecute, eventData);
   await saveResultsToRedis(hookToExec.id, results);


### PR DESCRIPTION
Hooks fire faster than Allocs can update data, this fixes that

Originally I didn't realize Allocs was returning stale data, so I made a whole helper + tests for loading stats. Didnt wanna throw it away though. Real fix for this issue is in 2nd commit