### PR TITLE
fix: permission when viewing ticket as server owner with no player-role

### DIFF
--- a/api/policies/canSeeTicket.js
+++ b/api/policies/canSeeTicket.js
@@ -16,8 +16,13 @@ module.exports = async function canSeeTicket(req, res, next) {
 
     let userRole = await sails.helpers.roles.getUserRole(user.id, server.id);
 
+    const permCheck = await sails.helpers.roles.checkPermission.with({
+      userId: user.id,
+      serverId: server.id,
+      permission: 'manageTickets'
+    });
 
-    if (user.steamId.toString() === ticket.player.steamId.toString() || userRole.manageTickets || userRole.manageServer) {
+    if (user.steamId.toString() === ticket.player.steamId.toString() || permCheck.hasPermission) {
       return next();
     } else {
       return res.view('meta/notauthorized', {


### PR DESCRIPTION
Users who had a CSMM owner who did not own the game were unable to view tickets