### PR TITLE
fix: handle request errors before piping them to the response

### DIFF
--- a/api/controllers/SdtdServer/server-tile.js
+++ b/api/controllers/SdtdServer/server-tile.js
@@ -48,17 +48,15 @@ module.exports = {
     const baseUrl = sails.helpers.sdtdApi.getBaseUrl(SdtdServer.getAPIConfig(server));
     const url = `${baseUrl}/map/${inputs.z}/${inputs.x}/${inputs.y}.png?adminuser=${server.authName}&admintoken=${server.authToken}`;
 
-    const reqHeaders = {...this.req.headers};
+    const reqHeaders = { ...this.req.headers };
     delete reqHeaders.host;
     delete reqHeaders.connection;
     delete reqHeaders['upgrade-insecure-requests'];
 
-    try {
-      request({ url: url, headers: reqHeaders }).pipe(this.res);
-    } catch (error) {
-      sails.log.error(`Error getting server-tile for ${url}`, error);
 
-      return exits.unknownError();
-    }
+    request({ url: url, headers: reqHeaders })
+      .on('error', function (err) {
+        return exits.unknownError(err);
+      }).pipe(this.res);
   }
 };


### PR DESCRIPTION
The errors are massive objects, piping all that into the response made CSMM crash horribly. 