### PR TITLE
fix: improper use of csrf header in form

### DIFF
--- a/views/sdtdServer/import.sejs
+++ b/views/sdtdServer/import.sejs
@@ -15,6 +15,7 @@
 
 
                 <form action="/api/admin/import" method="post" class="form-group" enctype="multipart/form-data">
+                    <input type="hidden" name="_csrf" value="<%= _csrf %>" />
                     <label for="file">Input JSON</label>
                     <input type="file" class="form-control-file" name="file" id="file" aria-describedby="fileHelpId">
                     <small id="fileHelpId" class="form-text text-muted">The JSON file to import</small>
@@ -23,7 +24,6 @@
                         placeholder="">
                     <small id="userIdHelp" class="form-text text-muted">The user ID this imported server should belong
                         to. When empty, it defaults to the currently logged in user</small>
-                    <input type="hidden" name="_csrf" value="<%= _csrf %>" />
                     <input class="btn btn-primary" type="submit" name="submit">
                 </form>
 


### PR DESCRIPTION
[app] 2021-04-01T20:23:42.640Z - verbose: Unable to expose body parameter `_csrf` in streaming upload!
[app] Client tried to send a text parameter (_csrf) after one or more files had already been sent.
[app] Make sure you always send text params first, then your files.
[app] (In an HTML form, it's as easy as making sure your text inputs are listed before your file inputs.