### PR TITLE
Add a configurable server name to command replies

### DIFF
--- a/api/controllers/SdtdServer/set-settings.js
+++ b/api/controllers/SdtdServer/set-settings.js
@@ -19,7 +19,12 @@ module.exports = {
 
     replyPrefix: {
       type: 'string'
-    }
+    },
+
+    replyServerName: {
+      type: 'string',
+      maxLength: 25
+    },
   },
   exits: {
     badRequest: {
@@ -44,6 +49,10 @@ module.exports = {
 
     if ('replyPrefix' in inputs) {
       updates.replyPrefix = inputs.replyPrefix;
+    }
+
+    if ('replyServerName' in inputs) {
+      updates.replyServerName = inputs.replyServerName;
     }
 
     sails.log.info(`ServerId ${inputs.serverId} updated settings to ${JSON.stringify(updates)}.`);

--- a/api/models/SdtdConfig.js
+++ b/api/models/SdtdConfig.js
@@ -191,6 +191,12 @@ module.exports = {
       allowNull: true
     },
 
+    replyServerName: {
+      type: 'string',
+      defaultsTo: '',
+      allowNull: true
+    },
+
     enabledCallAdmin: {
       type: 'boolean',
       defaultsTo: false

--- a/migrations/20210605180721-servername-for-reply.js
+++ b/migrations/20210605180721-servername-for-reply.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+      'sdtdconfig',
+      'replyServerName',
+      {
+        type: Sequelize.DataTypes.STRING(255),
+        allowNull: true,
+        default: '',
+      }
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(
+      'sdtdconfig',
+      'replyServerName'
+    );
+  }
+};

--- a/test/integration/controllers/set-settings.test.js
+++ b/test/integration/controllers/set-settings.test.js
@@ -10,6 +10,12 @@ describe('set-settings', function () {
       const config = await SdtdConfig.findOne({ server: sails.testServer.id });
       expect(config.replyPrefix).to.be.equal('blabla');
     });
+    it('Should set the replyServerName', async function () {
+      const response = await supertest(sails.hooks.http.app).post('/api/sdtdserver/settings').send({ replyServerName: 'replyServerName', serverId: sails.testServer.id });
+      expect(response.statusCode).to.equal(200);
+      const config = await SdtdConfig.findOne({ server: sails.testServer.id });
+      expect(config.replyServerName).to.be.equal('replyServerName');
+    });
     it('Should allow empty strings to be set', async function () {
       const response = await supertest(sails.hooks.http.app).post('/api/sdtdserver/settings').send({ replyPrefix: '', serverId: sails.testServer.id });
       expect(response.statusCode).to.equal(200);

--- a/test/unit/hooks/commands/commandHandler.test.js
+++ b/test/unit/hooks/commands/commandHandler.test.js
@@ -28,7 +28,7 @@ describe('COMMAND CommandHandler', () => {
       steamId: sails.testPlayer.steamId
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
-    expect(this.executeCommandStub.callCount).to.be.equal(1);
+    expect(this.executeCommandStub.callCount).to.be.equal(2);
     for (const call of this.executeCommandStub.getCalls()) {
       expect(call.lastArg).to.match(/pm \d* "test/);
     }
@@ -41,7 +41,7 @@ describe('COMMAND CommandHandler', () => {
       steamId: sails.testPlayer.steamId
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
-    expect(this.executeCommandStub.callCount).to.be.equal(1);
+    expect(this.executeCommandStub.callCount).to.be.equal(2);
   });
   it('Ignores chat messages sent by server', async () => {
     const chatMessage = {
@@ -84,7 +84,7 @@ describe('COMMAND CommandHandler', () => {
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
 
-    expect(this.executeCommandStub.callCount).to.be.equal(1);
+    expect(this.executeCommandStub.callCount).to.be.equal(2);
   });
 
   it('Commands are case insensitive', async () => {
@@ -93,7 +93,7 @@ describe('COMMAND CommandHandler', () => {
       steamId: sails.testPlayer.steamId
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
-    expect(this.executeCommandStub.callCount).to.be.equal(1);
+    expect(this.executeCommandStub.callCount).to.be.equal(2);
     for (const call of this.executeCommandStub.getCalls()) {
       expect(call.lastArg).to.match(/pm \d* .* PONG/);
     }

--- a/test/unit/hooks/commands/commandHandler.test.js
+++ b/test/unit/hooks/commands/commandHandler.test.js
@@ -29,9 +29,8 @@ describe('COMMAND CommandHandler', () => {
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
     expect(this.executeCommandStub.callCount).to.be.equal(2);
-    for (const call of this.executeCommandStub.getCalls()) {
-      expect(call.lastArg).to.match(/pm \d* "test/);
-    }
+    const calls = this.executeCommandStub.getCalls();
+    expect(calls[1].lastArg).to.match(/pm \d* "test/);
   });
 
   it('Does not execute a command if commands are disabled on server', async () => {
@@ -72,6 +71,7 @@ describe('COMMAND CommandHandler', () => {
     }
   });
   it('Can run custom commands', async () => {
+    sandbox.stub(sails.helpers.sdtdApi,'getStats').resolves({});
     await CustomCommand.create({
       name: 'test',
       commandsToExecute: 'say test',
@@ -84,7 +84,7 @@ describe('COMMAND CommandHandler', () => {
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
 
-    expect(this.executeCommandStub.callCount).to.be.equal(2);
+    expect(this.executeCommandStub.callCount).to.be.equal(1);
   });
 
   it('Commands are case insensitive', async () => {
@@ -94,8 +94,7 @@ describe('COMMAND CommandHandler', () => {
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
     expect(this.executeCommandStub.callCount).to.be.equal(2);
-    for (const call of this.executeCommandStub.getCalls()) {
-      expect(call.lastArg).to.match(/pm \d* .* PONG/);
-    }
+    const calls = this.executeCommandStub.getCalls();
+    expect(calls[1].lastArg).to.match(/pm \d* .* PONG/);
   });
 });

--- a/test/unit/hooks/commands/reply.test.js
+++ b/test/unit/hooks/commands/reply.test.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+const reply = require('../../../../worker/processors/sdtdCommands/sendReply');
+const sinon = require('sinon');
+
+describe('command reply', () => {
+  let spy;
+  beforeEach(() => {
+    spy = sandbox.stub(sails.helpers.sdtdApi, 'executeConsoleCommand').resolves(true);
+    sails.testServer.config = sails.testServerConfig;
+  });
+
+  it('Sends a pm to the player', async () => {
+    sandbox.stub(sails.helpers.sdtd, 'checkCpmVersion').returns(0);
+    await reply(sails.testServer, sails.testPlayer, 'something', {});
+    expect(spy).to.have.been.calledOnceWith(sinon.match.any, `pm ${sails.testPlayer.steamId} "something"`);
+  });
+
+  it('Can use replyType templates', async () => {
+    sandbox.stub(sails.helpers.sdtd, 'checkCpmVersion').returns(0);
+    await reply(sails.testServer, sails.testPlayer, 'error', {error: 'totally a real error'});
+    expect(spy).to.have.been.calledOnceWith(sinon.match.any, `pm ${sails.testPlayer.steamId} "Oh no, an error occurred! Please contact a server admin. Error: totally a real error"`);
+  });
+
+  it('Switches to pm2 when CPM is installed', async () => {
+    sandbox.stub(sails.helpers.sdtd, 'checkCpmVersion').returns(10.0);
+    sails.testServer.config.replyServerName = 'aaa';
+    await reply(sails.testServer, sails.testPlayer, 'message', {});
+    expect(spy).to.have.been.calledOnceWith(sinon.match.any, `pm2 "aaa" ${sails.testPlayer.steamId} "message"`);
+  });
+
+  it('Switches to pm2 when CPM is installed and defaults to "CSMM"', async () => {
+    sandbox.stub(sails.helpers.sdtd, 'checkCpmVersion').returns(10.0);
+    await reply(sails.testServer, sails.testPlayer, 'message', {});
+    expect(spy).to.have.been.calledOnceWith(sinon.match.any, `pm2 "CSMM" ${sails.testPlayer.steamId} "message"`);
+  });
+
+});

--- a/views/sdtdServer/partials/settings/commandSettings.sejs
+++ b/views/sdtdServer/partials/settings/commandSettings.sejs
@@ -100,6 +100,20 @@
 
     <button id="replyPrefix-btn" class="btn btn-primary">Save prefix</button>
 
+
+    <div class="form-group">
+      <label for="replyServerName">Reply server name</label>
+      <input type="text" class="form-control" name="replyServerName" id="replyServerName" aria-describedby="replyServerName-help"
+        placeholder="">
+      <small id="replyServerName-help" class="form-text text-muted">
+        <b>Requires CPM to be installed since this uses the "pm2" command</b>. 
+        Whenever CSMM replies to a player from a command, this will be the sender name.
+      </small>
+    </div>
+
+    <button id="replyServerName-btn" class="btn btn-primary">Save server name</button>
+
+
   </div>
 
 
@@ -551,6 +565,31 @@
         }
       });
     })
+
+    $("#replyServerName").val(window.SAILS_LOCALS.config.replyServerName);
+
+
+    $("#replyServerName-btn").click(e => {
+      let replyServerName = $("#replyServerName").val();
+      $.ajax({
+        url: `/api/sdtdserver/settings`,
+        type: 'POST',
+        data: {
+          _csrf: window.SAILS_LOCALS._csrf,
+          serverId: window.SAILS_LOCALS.server.id,
+          replyServerName: replyServerName
+        },
+        success: (data, status, xhr) => {
+
+        },
+        error: function (xhr, status, error) {
+          displayAjaxToSupportData(xhr, this);;
+          showErrorModal(`${error} - ${xhr.responseText}`, xhr);
+        }
+      });
+    })
+
+    
 
   })
 

--- a/worker/processors/sdtdCommands/sendReply.js
+++ b/worker/processors/sdtdCommands/sendReply.js
@@ -1,47 +1,56 @@
 const replyTypes = require('./replyTypes');
 
 module.exports = async function sendReplyToPlayer(server, player, type, data) {
-
-  function getReplyObj(type) {
-    return replyTypes.filter(r => r.type === type)[0];
-  }
-
-  async function getMessage(replyObj) {
-    let response = await CommandReply.find({
-      type: replyObj.type,
-      server: server.id
-    });
-    if (response.length === 0) {
-      return replyObj.default;
-    }
-    return response[0].reply;
-  }
   const replyObj = getReplyObj(type);
 
   if (!replyObj) {
-    return sendMsg(type);
+    return sendMsg(server, type, player);
   } else {
 
-    let message = await getMessage(replyObj);
+    let message = await getMessage(server, replyObj);
     if (!data) {
       data = {};
     }
     data.server = server;
     data.player = player;
     message = await sails.helpers.sdtd.fillCustomVariables(message, data);
-    return sendMsg(message);
-  }
-
-
-  function sendMsg(message) {
-
-    const { replyPrefix } = server.config;
-
-    if (replyPrefix) {
-      message = `${replyPrefix} ${message}`;
-    }
-
-    command = `pm ${player.steamId} "${message}"`;
-    return sails.helpers.sdtdApi.executeConsoleCommand(SdtdServer.getAPIConfig(server), command);
+    return sendMsg(server, message, player);
   }
 };
+
+function getReplyObj(type) {
+  return replyTypes.filter(r => r.type === type)[0];
+}
+
+
+async function getMessage(server, replyObj) {
+  let response = await CommandReply.find({
+    type: replyObj.type,
+    server: server.id
+  });
+  if (response.length === 0) {
+    return replyObj.default;
+  }
+  return response[0].reply;
+}
+
+async function sendMsg(server, message, player) {
+  const { replyPrefix, replyServerName } = server.config;
+  const cpmVersion = await sails.helpers.sdtd.checkCpmVersion(server.id);
+
+  console.log(replyServerName);
+
+  if (replyPrefix) {
+    message = `${replyPrefix} ${message}`;
+  }
+
+  if (cpmVersion) {
+    let serverName;
+    if (replyServerName) {serverName = replyServerName;} else {serverName = 'CSMM';}
+    command = `pm2 "${serverName}" ${player.steamId} "${message}"`;
+  } else {
+    command = `pm ${player.steamId} "${message}"`;
+  }
+
+  return sails.helpers.sdtdApi.executeConsoleCommand(SdtdServer.getAPIConfig(server), command);
+}

--- a/worker/processors/sdtdCommands/sendReply.js
+++ b/worker/processors/sdtdCommands/sendReply.js
@@ -38,8 +38,6 @@ async function sendMsg(server, message, player) {
   const { replyPrefix, replyServerName } = server.config;
   const cpmVersion = await sails.helpers.sdtd.checkCpmVersion(server.id);
 
-  console.log(replyServerName);
-
   if (replyPrefix) {
     message = `${replyPrefix} ${message}`;
   }


### PR DESCRIPTION
Requires CPM to be installed since this uses the "pm2" command

Whenever CSMM replies to a player from a command, this will be the sender name. Useful for customizing replies more, adding a colour (RIP the ugly red :)). When not configured, will default to 'CSMM'