### PR TITLE
feat: add a switch to allow disabling file logging

### DIFF
--- a/config/customLog.js
+++ b/config/customLog.js
@@ -23,7 +23,7 @@ const transports = [
   })
 ];
 
-if (!process.env.DISBLE_LOG_FILE) {
+if (!process.env.DISABLE_LOG_FILE) {
   transports.push(new winston.transports.File({
     level: 'info',
     name: 'infolog',
@@ -38,7 +38,7 @@ if (!process.env.DISBLE_LOG_FILE) {
 }
 
 
-if (!infoAndAbove.includes(logLevel) && !process.env.DISBLE_LOG_FILE) {
+if (!infoAndAbove.includes(logLevel) && !process.env.DISABLE_LOG_FILE) {
   transports.push(
     new winston.transports.File({
       level: logLevel,

--- a/config/customLog.js
+++ b/config/customLog.js
@@ -5,6 +5,7 @@ const logLevel = process.env.CSMM_LOGLEVEL || 'info';
 const infoAndAbove = ['info', 'warn', 'blank', 'crit'];
 
 const shouldLogJSON = JSON.parse((process.env.CSMM_LOG_JSON || 'false').toLowerCase());
+const disableFileLog = JSON.parse((process.env.DISABLE_LOG_FILE || 'false').toLowerCase());
 
 const logDirectory = process.env.LOGGING_DIR ? process.env.LOGGING_DIR : './logs';
 
@@ -23,7 +24,7 @@ const transports = [
   })
 ];
 
-if (!process.env.DISABLE_LOG_FILE) {
+if (!disableFileLog) {
   transports.push(new winston.transports.File({
     level: 'info',
     name: 'infolog',
@@ -38,7 +39,7 @@ if (!process.env.DISABLE_LOG_FILE) {
 }
 
 
-if (!infoAndAbove.includes(logLevel) && !process.env.DISABLE_LOG_FILE) {
+if (!infoAndAbove.includes(logLevel) && !disableFileLog) {
   transports.push(
     new winston.transports.File({
       level: logLevel,

--- a/config/customLog.js
+++ b/config/customLog.js
@@ -15,7 +15,16 @@ const simpleFormat = winston.format.combine(
 
 
 const transports = [
-  new winston.transports.File({
+  new winston.transports.Console({
+    level: logLevel,
+    timestamp: true,
+    humanReadableUnhandledException: true,
+    format: shouldLogJSON ? winston.format.json() : simpleFormat,
+  })
+];
+
+if (!process.env.DISBLE_LOG_FILE) {
+  transports.push(new winston.transports.File({
     level: 'info',
     name: 'infolog',
     timestamp: true,
@@ -25,17 +34,11 @@ const transports = [
     maxsize: 1000000,
     maxFiles: 3,
     format: shouldLogJSON ? winston.format.json() : simpleFormat,
-  }),
-  new winston.transports.Console({
-    level: logLevel,
-    timestamp: true,
-    humanReadableUnhandledException: true,
-    format: shouldLogJSON ? winston.format.json() : simpleFormat,
-  })
-];
+  }));
+}
 
 
-if (!infoAndAbove.includes(logLevel)) {
+if (!infoAndAbove.includes(logLevel) && !process.env.DISBLE_LOG_FILE) {
   transports.push(
     new winston.transports.File({
       level: logLevel,


### PR DESCRIPTION
So this was a fun one...

![image](https://user-images.githubusercontent.com/22315101/121479592-7a750c00-c9ca-11eb-8406-da80d970623a.png)


Disk space usage kept growing over time after some dependency updates. I assumed (wrongly ^^) that it was not rotating log files properly. Turns out, it was rotating log files HOWEVER the deleted files were still 'in use' by the process.

https://askubuntu.com/questions/413358/disk-is-full-but-cannot-find-big-files-or-folders

This might be a problem with Winston but I only saw this happening for the Docker instances. In Docker, it doesnt make much sense to log to a file. CSMM can log to stdout and let the logging infra take over.
So the 'fix' is to disable file logging :)

