### PR TITLE
Don't fully ignore server chat messages

### DIFF
--- a/test/unit/hooks/sdtdlogs/handleLogLine.test.js
+++ b/test/unit/hooks/sdtdlogs/handleLogLine.test.js
@@ -118,4 +118,22 @@ describe('sdtdLogs#handleLogLine', () => {
     expect(result.data.entityName).to.eq('cuteBambi');
 
   });
+
+  it('correctly detects a non-player chatmessage as a logline', () => {
+    const logLine = {
+      'date': '2017-11-14',
+      'time': '14:50:49',
+      'uptime': '133.559',
+      'msg': `Chat (from '-non-player-', entity id '-1', to 'Global'): 'Server': Catalysm: Server will restart in 13 MINUTES`,
+      'trace': '',
+      'type': 'Log'
+    };
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('logLine');
+    expect(result.data.steamId).to.eq('-non-player-');
+    expect(result.data.playerName).to.eq('Server');
+    expect(result.data.entityId).to.eq('-1');
+
+  });
 });

--- a/worker/processors/logs/handleLogLine.js
+++ b/worker/processors/logs/handleLogLine.js
@@ -104,11 +104,15 @@ module.exports = logLine => {
       (data.steamId === '-non-player-' && data.playerName !== 'Server') ||
       data.entityId === '-1'
     ) {
-      return;
+
+      returnValue.type = 'logLine';
+      returnValue.data = data;
+
+    } else {
+      returnValue.type = 'chatMessage';
+      returnValue.data = data;
     }
 
-    returnValue.type = 'chatMessage';
-    returnValue.data = data;
   }
 
   // pre A17 chat


### PR DESCRIPTION
In the past, server chat was completely ignored. However, it can still be useful to hook into these log lines. These messages will now be emitted as logLines