### PR TITLE
fix: custom functions arg parsing would truncate an arg is it starts …

### DIFF
--- a/test/util/customFunctions/base.test.js
+++ b/test/util/customFunctions/base.test.js
@@ -29,8 +29,11 @@ describe('CustomFunction base', function () {
     const x = `${Number.MAX_SAFE_INTEGER + 100}`;
     instance.run(sails.testServer, x);
     expect(stub).to.have.been.calledOnceWith(sails.testServer, [x]);
+  });
 
-
+  it('Returns a string without truncating if the message starts with an integer', async () => {
+    instance.run(sails.testServer, '12345 bla bla bla');
+    expect(stub).to.have.been.calledOnceWith(sails.testServer, ['12345 bla bla bla']);
   });
 
 });

--- a/worker/util/customFunctions/base.js
+++ b/worker/util/customFunctions/base.js
@@ -12,10 +12,14 @@ class CustomFunction {
     const splitArgs = split(args, { separator: ',', quotes: ['"', '\''] });
     return splitArgs.map(x => {
       x = x.trim().split('"').join('');
-      // To to parse as number
+      // Try to parse as number
       const num = parseInt(x, 10);
       if (Number.isNaN(num)) {
         // If it's not a number, just return the raw string
+        return x;
+        // If the length of x is larger than the amount of numbers in the string,
+        // We know parseInt truncated some part of the original string
+      } else if (x.length > num.toString().length) {
         return x;
       } else {
         // If it is a number, check if it's a safe integer


### PR DESCRIPTION
…with a number