### PR TITLE
build(docker): add make and align package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine AS builder
 
-RUN apk --no-cache add curl=7.79.1-r0 git=2.24.4-r0 jq=1.6-r0 python3=3.8.10-r0 make=4.2.1-r2
+RUN apk --no-cache add curl git jq python3 make g++
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine AS builder
 
-RUN apk --no-cache add curl=7.79.1-r0 git=2.32.0-r0 jq=1.6-r1 python3=3.9.5-r2
+RUN apk --no-cache add curl=7.79.1-r0 git=2.24.4-r0 jq=1.6-r0 python3=3.8.10-r0 make=4.2.1-r2
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csmm",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "csmm",
-      "version": "1.27.1",
+      "version": "1.27.2",
       "hasInstallScript": true,
       "dependencies": {
         "@budibase/handlebars-helpers": "^0.11.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csmm",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "csmm",
-      "version": "1.27.2",
+      "version": "1.27.3",
       "hasInstallScript": true,
       "dependencies": {
         "@budibase/handlebars-helpers": "^0.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csmm",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "description": "A 7dtd server manager made with Sails.js",
   "keywords": [],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csmm",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "description": "A 7dtd server manager made with Sails.js",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
It complained that the picked versions are not compatible. 

1. I removed all version numbers
2. build and copied the picked version numbers by my build
3. had to add make because it was not installed suddenly


Still, all this back and forth. Shouldn't we just remove the version numbers?

These are very common packages and breaking changes within a major are very unlikely.