### PR TITLE
Add more aliases to tp

### DIFF
--- a/worker/processors/sdtdCommands/commands/listTele.js
+++ b/worker/processors/sdtdCommands/commands/listTele.js
@@ -7,10 +7,10 @@ class listTele extends SdtdCommand {
       description: 'List teleport locations',
       extendedDescription: 'Lists your teleport locations. By providing a \'public\' argument, you will instead see a list of public teleports "$listtele public"',
       aliases: ['telelist', 'telels',
-	    'teleportlist', 'teleportls',
-		'tplist', 'tpls',
-		'listteleport', 'listtp',
-		'lstele', 'lsteleport', 'lstp']
+        'teleportlist', 'teleportls',
+        'tplist', 'tpls',
+        'listteleport', 'listtp',
+        'lstele', 'lsteleport', 'lstp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/listTele.js
+++ b/worker/processors/sdtdCommands/commands/listTele.js
@@ -6,7 +6,11 @@ class listTele extends SdtdCommand {
       name: 'listtele',
       description: 'List teleport locations',
       extendedDescription: 'Lists your teleport locations. By providing a \'public\' argument, you will instead see a list of public teleports "$listtele public"',
-      aliases: ['telelist', 'teleslist', 'listteles']
+      aliases: ['telelist', 'telels',
+	    'teleportlist', 'teleportls',
+		'tplist', 'tpls',
+		'listteleport', 'listtp',
+		'lstele', 'lsteleport', 'lstp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/removetele.js
+++ b/worker/processors/sdtdCommands/commands/removetele.js
@@ -7,12 +7,12 @@ class removeTele extends SdtdCommand {
       description: 'Remove a teleport location',
       extendedDescription: 'Delete a teleport location from the system',
       aliases: ['teleremove', 'telerm', 'teledelete', 'teledel',
-	    'teleportremove', 'teleportrm', 'teleportdelete', 'teleportdel',
-		'tpremove', 'tprm', 'tpdelete', 'tpdel',
-		'removeteleport', 'removetp',
-		'rmtele', 'rmteleport', 'rmtp',
-		'deletetele', 'deleteteleport', 'deletetp',
-		'deltele', 'delteleport', 'deltp']
+        'teleportremove', 'teleportrm', 'teleportdelete', 'teleportdel',
+        'tpremove', 'tprm', 'tpdelete', 'tpdel',
+        'removeteleport', 'removetp',
+        'rmtele', 'rmteleport', 'rmtp',
+        'deletetele', 'deleteteleport', 'deletetp',
+        'deltele', 'delteleport', 'deltp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/removetele.js
+++ b/worker/processors/sdtdCommands/commands/removetele.js
@@ -6,7 +6,13 @@ class removeTele extends SdtdCommand {
       name: 'removetele',
       description: 'Remove a teleport location',
       extendedDescription: 'Delete a teleport location from the system',
-      aliases: ['deltele', 'teledelete', 'deletetele', 'teleremove']
+      aliases: ['teleremove', 'telerm', 'teledelete', 'teledel',
+	    'teleportremove', 'teleportrm', 'teleportdelete', 'teleportdel',
+		'tpremove', 'tprm', 'tpdelete', 'tpdel',
+		'removeteleport', 'removetp',
+		'rmtele', 'rmteleport', 'rmtp',
+		'deletetele', 'deleteteleport', 'deletetp',
+		'deltele', 'delteleport', 'deltp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/renameTele.js
+++ b/worker/processors/sdtdCommands/commands/renameTele.js
@@ -7,7 +7,11 @@ class renameTele extends SdtdCommand {
       name: 'renametele',
       description: 'Rename a teleport location',
       extendedDescription: 'Arguments: oldname newname',
-      aliases: ['telerename']
+      aliases: ['telerename', 'telern',
+	    'teleportrename', 'teleportrn',
+		'tprename', 'tprn',
+		'renameteleport', 'renametp',
+		'rntele', 'rnteleport', 'rntp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/renameTele.js
+++ b/worker/processors/sdtdCommands/commands/renameTele.js
@@ -8,10 +8,10 @@ class renameTele extends SdtdCommand {
       description: 'Rename a teleport location',
       extendedDescription: 'Arguments: oldname newname',
       aliases: ['telerename', 'telern',
-	    'teleportrename', 'teleportrn',
-		'tprename', 'tprn',
-		'renameteleport', 'renametp',
-		'rntele', 'rnteleport', 'rntp']
+        'teleportrename', 'teleportrn',
+        'tprename', 'tprn',
+        'renameteleport', 'renametp',
+        'rntele', 'rnteleport', 'rntp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/setTele.js
+++ b/worker/processors/sdtdCommands/commands/setTele.js
@@ -8,10 +8,10 @@ class setTele extends SdtdCommand {
       description: 'Create a teleport location',
       extendedDescription: 'Creates a teleport location at your current position. Arguments: name',
       aliases: ['teleset', 'telecreate',
-	    'teleportset', 'teleportcreate',
-		'tpset', 'tpcreate',
-		'setteleport', 'settp',
-		'createtele', 'createteleport', 'createtp']
+        'teleportset', 'teleportcreate',
+        'tpset', 'tpcreate',
+        'setteleport', 'settp',
+        'createtele', 'createteleport', 'createtp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/setTele.js
+++ b/worker/processors/sdtdCommands/commands/setTele.js
@@ -7,7 +7,11 @@ class setTele extends SdtdCommand {
       name: 'settele',
       description: 'Create a teleport location',
       extendedDescription: 'Creates a teleport location at your current position. Arguments: name',
-      aliases: ['teleset', 'telecreate']
+      aliases: ['teleset', 'telecreate',
+	    'teleportset', 'teleportcreate',
+		'tpset', 'tpcreate',
+		'setteleport', 'settp',
+		'createtele', 'createteleport', 'createtp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/telePublic.js
+++ b/worker/processors/sdtdCommands/commands/telePublic.js
@@ -6,7 +6,11 @@ class telePublic extends SdtdCommand {
       name: 'telepublic',
       description: 'Make a teleport public',
       extendedDescription: 'Let everyone on the server teleport to a location',
-      aliases: ['telepub', 'pubtele', 'publictele']
+      aliases: ['telepub',
+	    'teleportpublic', 'teleportpub',
+		'tppublic', 'tppub',
+		'publictele', 'publicteleport', 'publictp',
+		'pubtele', 'pubteleport', 'pubtp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/telePublic.js
+++ b/worker/processors/sdtdCommands/commands/telePublic.js
@@ -7,10 +7,10 @@ class telePublic extends SdtdCommand {
       description: 'Make a teleport public',
       extendedDescription: 'Let everyone on the server teleport to a location',
       aliases: ['telepub',
-	    'teleportpublic', 'teleportpub',
-		'tppublic', 'tppub',
-		'publictele', 'publicteleport', 'publictp',
-		'pubtele', 'pubteleport', 'pubtp']
+        'teleportpublic', 'teleportpub',
+        'tppublic', 'tppub',
+        'publictele', 'publicteleport', 'publictp',
+        'pubtele', 'pubteleport', 'pubtp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/teleprivate.js
+++ b/worker/processors/sdtdCommands/commands/teleprivate.js
@@ -7,10 +7,10 @@ class telePrivate extends SdtdCommand {
       description: 'Make a teleport private',
       extendedDescription: 'When a teleport is private, only you can use it.',
       aliases: ['telepriv',
-	    'teleportprivate', 'teleportpriv',
-		'tpprivate', 'tppriv',
-		'privatetele', 'privateteleport', 'privatetp',
-		'privtele', 'privteleport', 'privtp']
+        'teleportprivate', 'teleportpriv',
+        'tpprivate', 'tppriv',
+        'privatetele', 'privateteleport', 'privatetp',
+        'privtele', 'privteleport', 'privtp']
     });
   }
 

--- a/worker/processors/sdtdCommands/commands/teleprivate.js
+++ b/worker/processors/sdtdCommands/commands/teleprivate.js
@@ -6,7 +6,11 @@ class telePrivate extends SdtdCommand {
       name: 'teleprivate',
       description: 'Make a teleport private',
       extendedDescription: 'When a teleport is private, only you can use it.',
-      aliases: ['privatetele', 'privtele', 'telepriv']
+      aliases: ['telepriv',
+	    'teleportprivate', 'teleportpriv',
+		'tpprivate', 'tppriv',
+		'privatetele', 'privateteleport', 'privatetp',
+		'privtele', 'privteleport', 'privtp']
     });
   }
 


### PR DESCRIPTION
The tp commands only have a few aliases which are inconsistent between the commands and do not completely represent industry standard aliases for similar commands in other systems. This changeset adds aliases to improve those consistency and familiarity factors.