### PR TITLE
fix: do not clear isConnecting flag on errors

### DIFF
--- a/api/hooks/sdtdLogs/eventDetectors/7d2dSSE.js
+++ b/api/hooks/sdtdLogs/eventDetectors/7d2dSSE.js
@@ -111,7 +111,6 @@ class SdtdSSE extends LoggingObject {
     this.eventSource.onerror = e => {
       clearTimeout(isConnectingTimeout);
       sails.log.warn(`SSE error for server ${this.server.id}`, { server: this.server, error: e });
-      this.isConnecting = false;
     };
     this.eventSource.onopen = () => {
       clearTimeout(isConnectingTimeout);
@@ -129,6 +128,7 @@ class SdtdSSE extends LoggingObject {
     this.eventSource.removeEventListener('logLine', this.listener);
     this.eventSource.close();
     this.eventSource = null;
+    this.isConnecting = false;
   }
 
   async SSEListener(data) {

--- a/api/hooks/sdtdLogs/eventDetectors/7d2dSSE.js
+++ b/api/hooks/sdtdLogs/eventDetectors/7d2dSSE.js
@@ -109,7 +109,6 @@ class SdtdSSE extends LoggingObject {
     this.eventSource.reconnectInterval = 5000;
     this.eventSource.addEventListener('logLine', this.listener);
     this.eventSource.onerror = e => {
-      clearTimeout(isConnectingTimeout);
       sails.log.warn(`SSE error for server ${this.server.id}`, { server: this.server, error: e });
     };
     this.eventSource.onopen = () => {


### PR DESCRIPTION
There's many reasons that an error occurs and we should not always clear this flag. This change will cause the system to be a bit slower when having to retry connections, but will be more fault tolerant