### PR TITLE
fix: refactor how old data gets deleted

### DIFF
--- a/api/helpers/economy/deduct-from-player.js
+++ b/api/helpers/economy/deduct-from-player.js
@@ -72,9 +72,6 @@ module.exports = {
       economyAction: 'deduct'
     });
 
-    await sails.helpers.redis.incr(`server:${playerToDeductFrom.server}:economyActionsCompleted`);
-    await sails.helpers.economy.deleteOldData(playerToDeductFrom.server);
-
     return exits.success();
   }
 };

--- a/api/helpers/economy/delete-old-data.js
+++ b/api/helpers/economy/delete-old-data.js
@@ -1,22 +1,15 @@
 module.exports = {
-
-
   friendlyName: 'Delete old data',
-
 
   description: 'Delete old economy data',
 
-
   inputs: {
-
     serverId: {
       type: 'number',
       description: 'Id of the server',
-      required: true
+      required: true,
     },
-
   },
-
 
   exits: {
     success: {
@@ -25,29 +18,27 @@ module.exports = {
   },
 
   fn: async function (inputs, exits) {
+    let donatorRole = await sails.helpers.meta.checkDonatorStatus.with({
+      serverId: inputs.serverId,
+    });
+    let hoursToKeepData =
+      sails.config.custom.donorConfig[donatorRole].economyKeepDataHours;
+    let milisecondsToKeepData = hoursToKeepData * 3600000;
+    let dateNow = Date.now();
+    let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
 
-    let actionsCompleted = await sails.helpers.redis.get(`server:${inputs.serverId}:economyActionsCompleted`);
-    sails.log.verbose(`Server ${inputs.serverId} has completed ${actionsCompleted} economy actions - checking if these need to be deleted.`, {serverId: inputs.serverId});
-    if (actionsCompleted && actionsCompleted > sails.config.custom.economyActionsBeforeDelete) {
-      await sails.helpers.redis.set(`server:${inputs.serverId}:economyActionsCompleted`, 1);
-      let donatorRole = await sails.helpers.meta.checkDonatorStatus.with({
-        serverId: inputs.serverId
-      });
-      let hoursToKeepData = sails.config.custom.donorConfig[donatorRole].economyKeepDataHours;
-      let milisecondsToKeepData = hoursToKeepData * 3600000;
-      let dateNow = Date.now();
-      let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
+    await HistoricalInfo.destroy({
+      createdAt: {
+        '<': borderDate.valueOf(),
+      },
+      type: 'economy',
+      server: inputs.serverId,
+    });
+    sails.log.debug(
+      `Deleted old historical info for server ${inputs.serverId}`,
+      { serverId: inputs.serverId }
+    );
 
-      await HistoricalInfo.destroy({
-        createdAt: {
-          '<': borderDate.valueOf()
-        },
-        type: 'economy',
-        server: inputs.serverId
-      });
-      sails.log.debug(`Deleted old historical info for server ${inputs.serverId}`, {serverId: inputs.serverId});
-    }
     return exits.success();
-
-  }
+  },
 };

--- a/api/helpers/economy/give-to-player.js
+++ b/api/helpers/economy/give-to-player.js
@@ -62,9 +62,6 @@ module.exports = {
       economyAction: 'give'
     });
 
-    await sails.helpers.redis.incr(`server:${playerToGiveTo.server}:economyActionsCompleted`);
-    await sails.helpers.economy.deleteOldData(playerToGiveTo.server);
-
     return exits.success();
   }
 };

--- a/api/hooks/historicalInfo/objects/memUpdate.js
+++ b/api/hooks/historicalInfo/objects/memUpdate.js
@@ -21,17 +21,6 @@ class MemUpdate {
     sails.log.debug(`Received a mem update for server ${this.server.name}`, {server: this.server});
     await sails.helpers.redis.set(`server:${this.server.id}:fps`, memUpdate.fps);
     await saveInfoToDatabase(this.server, memUpdate);
-
-    let currentCycles = await sails.helpers.redis.get(`server:${this.server.id}:trackingCyclesCompleted`);
-    currentCycles = parseInt(currentCycles);
-
-    if (!currentCycles) {
-      currentCycles = 1;
-    }
-    sails.log.debug(`HOOK - historicalInfo - checking if we need to delete data - ${currentCycles}/${sails.config.custom.trackingCyclesBeforeDelete} cycles`, {server: this.server});
-    if (currentCycles >= sails.config.custom.trackingCyclesBeforeDelete) {
-      await clearOldInfo(this.server, this.config);
-    }
   }
 
   get type() {
@@ -60,27 +49,6 @@ async function saveInfoToDatabase(server, memUpdate) {
   } catch (error) {
     sails.log.error(`HOOKS - Analytics:memUpdate - Error saving data -${error}`, {server});
   }
-}
-
-async function clearOldInfo(server) {
-  try {
-    let donatorRole = await sails.helpers.meta.checkDonatorStatus.with({
-      serverId: server.id
-    });
-    let hoursToKeepData = sails.config.custom.donorConfig[donatorRole].memUpdateKeepDataHours;
-    let milisecondsToKeepData = hoursToKeepData * 3600000;
-    let dateNow = Date.now();
-    let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
-
-    await sails.sendNativeQuery(`DELETE FROM analytics WHERE server = $1 AND createdAt < $2;`, [server.id, borderDate.valueOf()]);
-
-    let dateEnded = Date.now();
-
-    sails.log.debug(`Deleted historical data of type memUpdate for server ${server.id} - took ${dateEnded - dateNow} ms`, {server});
-  } catch (error) {
-    sails.log.error(`HOOKS - Analytics:memUpdate - Error deleting data - ${error}`, {server});
-  }
-
 }
 
 module.exports = MemUpdate;

--- a/config/custom.js
+++ b/config/custom.js
@@ -48,14 +48,6 @@ module.exports.custom = {
   currentAllocs: '31',
   currentCpm: '9.4',
 
-  // TRACKING
-
-  trackingCyclesBeforeDelete: 25,
-
-  // Economy
-
-  economyActionsBeforeDelete: process.env.ECONOMY_ACTIONS_BEFORE_DELETE || 1000,
-
   // Custom hooks
 
   supportedHooks: ['playerConnected', 'playerDisconnected', 'chatMessage', 'playerDeath', 'playerJoined', 'playerLevel', 'zombieKilled', 'animalKilled', 'playerKilled', 'logLine', 'playerSuicide'],

--- a/test/unit/hooks/playerTracking/playerTracking.test.js
+++ b/test/unit/hooks/playerTracking/playerTracking.test.js
@@ -71,33 +71,6 @@ describe('Player tracking', () => {
 
   });
 
-  it('Deletes data after a certain time period', async () => {
-    sandbox.stub(sails.helpers.sdtd, 'getOnlinePlayers').returns(['player1', 'player2']);
-    sandbox.stub(SdtdServer, 'findOne').returns({
-      populate: () => {
-        return {
-          ...sails.testServer,
-          config: [{
-            ...sails.testServer.config,
-            locationTracking: true,
-            inventoryTracking: true
-          }]
-        };
-      }
-    });
-
-    sandbox.stub(sails.helpers.redis, 'get').returns(sails.config.custom.trackingCyclesBeforeDelete + 1);
-    sandbox.stub(sails, 'sendNativeQuery').returns({ affectedRows: 1337 });
-
-    // Kinda scuffed, we overwrite the redis getter earlier so this overwrite is weird ^^
-    sails.config.custom.donorConfig[sails.config.custom.trackingCyclesBeforeDelete + 1] = {};
-    sails.config.custom.donorConfig[sails.config.custom.trackingCyclesBeforeDelete + 1].playerTrackerKeepLocationHours = 8;
-
-    await hook({data: {serverId: sails.testServer.id}});
-
-    expect(sails.sendNativeQuery).to.have.been.calledOnceWith('DELETE FROM trackinginfo WHERE server = $1 AND createdAt < $2;', sinon.match.any);
-  });
-
   describe('basicTracking', () => {
 
     it('Updates player records', async () => {

--- a/worker/processors/playerTracking/index.js
+++ b/worker/processors/playerTracking/index.js
@@ -1,11 +1,11 @@
 const trackingFunctions = require('./trackingFunctions');
 
-
 module.exports = async function playerTracking(job) {
-  sails.log.debug('[Worker] Got a `playerTracking` job', {serverId: job.data.serverId});
+  sails.log.debug('[Worker] Got a `playerTracking` job', {
+    serverId: job.data.serverId,
+  });
   return doTracking(job.data);
 };
-
 
 async function doTracking(serverId) {
   let dateStarted = new Date();
@@ -13,13 +13,18 @@ async function doTracking(serverId) {
   let server = await SdtdServer.findOne({ id: serverId }).populate('config');
 
   if (_.isUndefined(server)) {
-    return sails.log.warn(`Player tracking - Could not find server info during tracking!`, { serverId });
+    return sails.log.warn(
+      `Player tracking - Could not find server info during tracking!`,
+      { serverId }
+    );
   }
 
   let onlinePlayers = await sails.helpers.sdtd.getOnlinePlayers(server.id);
 
   if (!onlinePlayers) {
-    sails.log.error(`Unexpected value for onlinePlayers: ${onlinePlayers}`, {serverId});
+    sails.log.error(`Unexpected value for onlinePlayers: ${onlinePlayers}`, {
+      serverId,
+    });
     return;
   }
 
@@ -31,77 +36,50 @@ async function doTracking(serverId) {
 
   let playerRecords = await Player.find({
     server: server.id,
-    steamId: onlinePlayers.map(playerInfo => playerInfo.steamid)
+    steamId: onlinePlayers.map((playerInfo) => playerInfo.steamid),
   });
 
   for (const playerRecord of playerRecords) {
-
     initialValues.push({
       server: server.id,
-      player: playerRecord.id
+      player: playerRecord.id,
     });
   }
 
-
   await trackingFunctions.basic(server, onlinePlayers, playerRecords);
-
 
   if (server.config[0].locationTracking || server.config[0].inventoryTracking) {
     // If inventory OR location tracking is enabled, we prepare the tracking info beforehand to improve performance
 
     if (server.config[0].locationTracking) {
-
-      initialValues = await trackingFunctions.location(server, onlinePlayers, initialValues, playerRecords);
+      initialValues = await trackingFunctions.location(
+        server,
+        onlinePlayers,
+        initialValues,
+        playerRecords
+      );
     }
 
     if (server.config[0].inventoryTracking) {
+      initialValues = await trackingFunctions.inventory(
+        server,
+        onlinePlayers,
+        initialValues,
+        playerRecords
+      );
 
-
-      initialValues = await trackingFunctions.inventory(server, onlinePlayers, initialValues, playerRecords);
-
-      await sails.helpers.getQueueObject('bannedItems').add({ server, trackingInfo: initialValues });
+      await sails.helpers
+        .getQueueObject('bannedItems')
+        .add({ server, trackingInfo: initialValues });
     }
     await TrackingInfo.createEach(initialValues);
-
-  }
-
-  let currentCycles = await sails.helpers.redis.get(`server:${serverId}:trackingCyclesCompleted`);
-  currentCycles = parseInt(currentCycles);
-
-  if (!currentCycles) {
-    currentCycles = 1;
-  }
-
-  if (currentCycles >= sails.config.custom.trackingCyclesBeforeDelete) {
-    await deleteLocationData(server);
-    await sails.helpers.redis.set(`server:${serverId}:trackingCyclesCompleted`, 0);
-  } else {
-    await sails.helpers.redis.incr(`server:${serverId}:trackingCyclesCompleted`);
   }
 
   let dateEnded = new Date();
-  sails.log.debug(`Player tracking - Performed tracking for server ${server.name} - ${playerRecords.length} players online - ${currentCycles}/${sails.config.custom.trackingCyclesBeforeDelete} tracking cycles - took ${dateEnded.valueOf() - dateStarted.valueOf()} ms`, {server});
-
-}
-
-
-async function deleteLocationData(server) {
-  let dateNow = Date.now();
-  let deleteResult;
-
-  let donatorRole = await sails.helpers.meta.checkDonatorStatus.with({
-    serverId: server.id
-  });
-
-  let hoursToKeepData = sails.config.custom.donorConfig[donatorRole].playerTrackerKeepLocationHours;
-  let milisecondsToKeepData = hoursToKeepData * 3600000;
-  let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
-
-  const locationDeleteSQL = `DELETE FROM trackinginfo WHERE server = $1 AND createdAt < $2;`;
-
-  deleteResult = await sails.sendNativeQuery(locationDeleteSQL, [server.id, borderDate.valueOf()]);
-
-
-  let dateEnded = new Date();
-  sails.log.debug(`Deleted location data for server ${server.name} - deleted ${deleteResult.affectedRows} rows - took ${dateEnded.valueOf() - dateNow.valueOf()} ms`, {server});
+  sails.log.debug(
+    `Player tracking - Performed tracking for server ${server.name} - ${
+      playerRecords.length
+    } players online - took ${dateEnded.valueOf() - dateStarted.valueOf()} ms`,
+    { server }
+  );
 }

--- a/worker/processors/system/historicalDataCleanup.js
+++ b/worker/processors/system/historicalDataCleanup.js
@@ -1,0 +1,79 @@
+module.exports = async function historicalDataCleanup() {
+  const serversPerPage = 10;
+  const serverCount = await SdtdServer.count();
+
+  for (let i = 0; i < serverCount / serversPerPage; i++) {
+    const serversToCheck = await SdtdServer.find({
+      skip: serversPerPage * i,
+      limit: serversPerPage,
+      where: {
+        disabled: false,
+      },
+    });
+
+    for (const server of serversToCheck) {
+      try {
+        await sails.helpers.economy.deleteOldData(server.id);
+        await cleanUpMemUpdate(server.id);
+        await cleanUpLocationData(server.id);
+      } catch (error) {
+        sails.log.error(error, { server });
+        continue;
+      }
+    }
+  }
+};
+
+async function cleanUpMemUpdate(serverId) {
+  let donatorRole = await sails.helpers.meta.checkDonatorStatus.with({
+    serverId,
+  });
+  let hoursToKeepData =
+    sails.config.custom.donorConfig[donatorRole].memUpdateKeepDataHours;
+  let milisecondsToKeepData = hoursToKeepData * 3600000;
+  let dateNow = Date.now();
+  let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
+
+  await sails.sendNativeQuery(
+    `DELETE FROM analytics WHERE server = $1 AND createdAt < $2;`,
+    [serverId, borderDate.valueOf()]
+  );
+
+  let dateEnded = Date.now();
+
+  sails.log.debug(
+    `Deleted historical data of type memUpdate for server ${serverId} - took ${
+      dateEnded - dateNow
+    } ms`,
+    { server: serverId }
+  );
+}
+
+async function cleanUpLocationData(serverId) {
+  let deleteResult;
+  let dateNow = Date.now();
+
+  let donatorRole = await sails.helpers.meta.checkDonatorStatus.with({
+    serverId,
+  });
+
+  let hoursToKeepData =
+    sails.config.custom.donorConfig[donatorRole].playerTrackerKeepLocationHours;
+  let milisecondsToKeepData = hoursToKeepData * 3600000;
+  let borderDate = new Date(dateNow.valueOf() - milisecondsToKeepData);
+
+  const locationDeleteSQL = `DELETE FROM trackinginfo WHERE server = $1 AND createdAt < $2;`;
+
+  deleteResult = await sails.sendNativeQuery(locationDeleteSQL, [
+    serverId,
+    borderDate.valueOf(),
+  ]);
+
+  let dateEnded = new Date();
+  sails.log.debug(
+    `Deleted location data for server ${serverId} - deleted ${
+      deleteResult.affectedRows
+    } rows - took ${dateEnded.valueOf() - dateNow.valueOf()} ms`,
+    { server: serverId }
+  );
+}

--- a/worker/processors/system/index.js
+++ b/worker/processors/system/index.js
@@ -1,5 +1,6 @@
 const donorCheck = require('./donorCheck');
 const playerCleanup = require('./playerCleanup');
+const historicalDataCleanup = require('./historicalDataCleanup');
 
 module.exports = async function system(job) {
   sails.log.debug('[Worker] Got a `system` job');
@@ -11,9 +12,10 @@ module.exports = async function system(job) {
     case 'playerCleanup':
       await playerCleanup(job);
       break;
+    case 'historicalDataCleanup':
+      await historicalDataCleanup(job);
+      break;
     default:
       throw new Error(`Unknown system job type "${job.data.type}", discarding`);
   }
-
 };
-


### PR DESCRIPTION
By putting it inside the worker, we can reduce the load on the system significantly. With the old implementation, there was also a bug where multiple deletes where happening at the same time.