### PR TITLE
fix: do not send command disabled message

### DIFF
--- a/worker/processors/sdtdCommands/index.js
+++ b/worker/processors/sdtdCommands/index.js
@@ -61,7 +61,7 @@ async function commandListener(job) {
     let commandIsEnabled = await commandToRun.isEnabled(chatMessage, player, server, args);
 
     if (!commandIsEnabled) {
-      return chatMessage.reply(`commandDisabled`);
+      return;
     }
 
     try {


### PR DESCRIPTION
This is bad when people are moving to Takaro and have certain CSMM commands disabled. Causes confusion for players