### PR TITLE
Add support for PrismaCore mod detection

### DIFF
--- a/api/controllers/SdtdServer/get-mod-version.js
+++ b/api/controllers/SdtdServer/get-mod-version.js
@@ -15,7 +15,7 @@ module.exports = {
     mod: {
       type: 'string',
       required: true,
-      isIn: ['cpm', 'allocs']
+      isIn: ['cpm', 'allocs', 'prismacore']
     }
 
   },
@@ -29,7 +29,7 @@ module.exports = {
 
   fn: async function (inputs, exits) {
 
-    if (inputs.mod.includes('cpm')) {
+    if (inputs.mod.includes('cpm') || inputs.mod.includes('prismacore')) {
       inputs.mod = 'Mod CSMM Patrons';
     }
 

--- a/api/helpers/sdtd/check-cpm-version.js
+++ b/api/helpers/sdtd/check-cpm-version.js
@@ -39,6 +39,8 @@ module.exports = {
         apiResponse = (await Promise.all([
           sails.helpers.sdtd.checkModVersion('Mod CSMM Patrons', inputs.serverId),
           sails.helpers.sdtd.checkModVersion('Mod 1CSMM_Patrons', inputs.serverId),
+          sails.helpers.sdtd.checkModVersion('Mod PrismaCore', inputs.serverId),
+          sails.helpers.sdtd.checkModVersion('Mod 1PrismaCore', inputs.serverId),
         ])).find(v => !!v) || 0;
       } catch (e) {
         return exits.error(e);

--- a/test/unit/helpers/sdtd/check-mod-version.test.js
+++ b/test/unit/helpers/sdtd/check-mod-version.test.js
@@ -13,6 +13,32 @@ describe('HELPER sdtd/check-mod-version', () => {
     const result = await sails.helpers.sdtd.checkModVersion('Mod Allocs MapRendering and Webinterface', sails.testServer.id);
     expect(result).to.eql(33.2);
   });
+
+  it('returns version for Mod PrismaCore', async () => {
+    sandbox.stub(sails.helpers.sdtdApi, 'executeConsoleCommand').callsFake(async function() {
+      return {
+        command: 'version',
+        parameters: '',
+        result: 'Game version: Alpha 21 (b317) Compatibility Version: Alpha 21\r\n' +
+          'Mod PrismaCore: 7.2\r\n'
+      };
+    });
+    const result = await sails.helpers.sdtd.checkModVersion('Mod PrismaCore', sails.testServer.id);
+    expect(result).to.eql(7.2);
+  });
+
+  it('returns version for Mod 1PrismaCore', async () => {
+    sandbox.stub(sails.helpers.sdtdApi, 'executeConsoleCommand').callsFake(async function() {
+      return {
+        command: 'version',
+        parameters: '',
+        result: 'Game version: Alpha 21 (b317) Compatibility Version: Alpha 21\r\n' +
+          'Mod 1PrismaCore: 7.2\r\n'
+      };
+    });
+    const result = await sails.helpers.sdtd.checkModVersion('Mod 1PrismaCore', sails.testServer.id);
+    expect(result).to.eql(7.2);
+  });
 });
 
 

--- a/test/unit/hooks/commands/commandHandler.test.js
+++ b/test/unit/hooks/commands/commandHandler.test.js
@@ -28,9 +28,9 @@ describe('COMMAND CommandHandler', () => {
       steamId: sails.testPlayer.steamId
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
-    expect(this.executeCommandStub.callCount).to.be.equal(3);
+    expect(this.executeCommandStub.callCount).to.be.equal(5);
     const calls = this.executeCommandStub.getCalls();
-    expect(calls[2].lastArg).to.match(/pm \d* "test/);
+    expect(calls[4].lastArg).to.match(/pm \d* "test/);
   });
 
   it('Does not execute a command if commands are disabled on server', async () => {
@@ -40,7 +40,7 @@ describe('COMMAND CommandHandler', () => {
       steamId: sails.testPlayer.steamId
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
-    expect(this.executeCommandStub.callCount).to.be.equal(3);
+    expect(this.executeCommandStub.callCount).to.be.equal(5);
   });
   it('Ignores chat messages sent by server', async () => {
     const chatMessage = {
@@ -93,8 +93,8 @@ describe('COMMAND CommandHandler', () => {
       steamId: sails.testPlayer.steamId
     };
     await commandListener({data: {data: chatMessage, server: sails.testServer}});
-    expect(this.executeCommandStub.callCount).to.be.equal(3);
+    expect(this.executeCommandStub.callCount).to.be.equal(5);
     const calls = this.executeCommandStub.getCalls();
-    expect(calls[2].lastArg).to.match(/pm \d* .* PONG/);
+    expect(calls[4].lastArg).to.match(/pm \d* .* PONG/);
   });
 });

--- a/test/unit/hooks/sdtdlogs/handleLogLine.test.js
+++ b/test/unit/hooks/sdtdlogs/handleLogLine.test.js
@@ -246,6 +246,63 @@ describe('sdtdLogs#handleLogLine', () => {
 
   });
 
+  it('correctly detects a PrismaCore playerLevel event', () => {
+    const logLine = {
+      'date': '2020-07-11',
+      'time': '08:11:40',
+      'uptime': '1673.118',
+      'msg': '[PrismaCore]playerLeveled: (VE) Kiota (76561198108856299) made level 4 (was 3)',
+      'trace': '',
+      'type': 'Log'
+    };
+
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('playerLevel');
+    expect(result.data.steamId).to.eq('76561198108856299');
+    expect(result.data.newLvl).to.eq('4');
+    expect(result.data.oldLvl).to.eq('3');
+
+  });
+
+  it('correctly detects a PrismaCore A20 playerLevel event', () => {
+    const logLine = {
+      'date': '2020-07-11',
+      'time': '08:11:40',
+      'uptime': '1673.118',
+      'msg': '[PrismaCore]playerLeveled: Catalysm (Steam_76561198028175941) made level 2 (was 1)',
+      'trace': '',
+      'type': 'Log'
+    };
+
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('playerLevel');
+    expect(result.data.steamId).to.eq('76561198028175941');
+    expect(result.data.newLvl).to.eq('2');
+    expect(result.data.oldLvl).to.eq('1');
+
+  });
+
+  it('correctly detects a PrismaCore XBL player playerLevel event', () => {
+    const logLine = {
+      'date': '2020-07-11',
+      'time': '08:11:40',
+      'uptime': '1673.118',
+      'msg': '[PrismaCore]playerLeveled: player (XBL_FA8E82BBF713BA2A53D74196F3D158368D344D7F) made level 135 (was 133)',
+      'trace': '',
+      'type': 'Log'
+    };
+
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('playerLevel');
+    expect(result.data.steamId).to.eq('XBL_FA8E82BBF713BA2A53D74196F3D158368D344D7F');
+    expect(result.data.newLvl).to.eq('135');
+    expect(result.data.oldLvl).to.eq('133');
+
+  });
+
   it('correctly detects a zombieKilled event', () => {
     const logLine = {
       'date': '2017-11-14',
@@ -282,6 +339,42 @@ describe('sdtdLogs#handleLogLine', () => {
 
   });
 
+  it('correctly detects a PrismaCore zombieKilled event', () => {
+    const logLine = {
+      'date': '2017-11-14',
+      'time': '14:50:49',
+      'uptime': '133.559',
+      'msg': '[PrismaCore]entityKilled: (VE) Kiota (76561198028175941) killed zombie zombieBoe',
+      'trace': '',
+      'type': 'Log'
+    };
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('zombieKilled');
+    expect(result.data.steamId).to.eq('76561198028175941');
+    expect(result.data.entityClass).to.eq('zombie');
+    expect(result.data.entityName).to.eq('zombieBoe');
+
+  });
+
+  it('correctly detects a PrismaCore a20 zombieKilled event', () => {
+    const logLine = {
+      'date': '2017-11-14',
+      'time': '14:50:49',
+      'uptime': '133.559',
+      'msg': '[PrismaCore]entityKilled: Catalysm (Steam_76561198028175941) killed zombie zombieYo with Dev: Instant Death Pistol',
+      'trace': '',
+      'type': 'Log'
+    };
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('zombieKilled');
+    expect(result.data.steamId).to.eq('76561198028175941');
+    expect(result.data.entityClass).to.eq('zombie');
+    expect(result.data.entityName).to.eq('zombieYo');
+
+  });
+
   it('correctly detects a animalKilled event', () => {
     const logLine = {
       'date': '2017-11-14',
@@ -306,6 +399,42 @@ describe('sdtdLogs#handleLogLine', () => {
       'time': '14:50:49',
       'uptime': '133.559',
       'msg': '[CSMM_Patrons]entityKilled: Catalysm (Steam_76561198028175941) killed animal animalZombieDog with Dev: Instant Death Pistol',
+      'trace': '',
+      'type': 'Log'
+    };
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('animalKilled');
+    expect(result.data.steamId).to.eq('76561198028175941');
+    expect(result.data.entityClass).to.eq('animal');
+    expect(result.data.entityName).to.eq('animalZombieDog');
+
+  });
+
+  it('correctly detects a PrismaCore animalKilled event', () => {
+    const logLine = {
+      'date': '2017-11-14',
+      'time': '14:50:49',
+      'uptime': '133.559',
+      'msg': '[PrismaCore]entityKilled: (VE) Kiota (76561198028175941) killed animal cuteBambi',
+      'trace': '',
+      'type': 'Log'
+    };
+    const result = handleLogLine(logLine);
+
+    expect(result.type).to.eq('animalKilled');
+    expect(result.data.steamId).to.eq('76561198028175941');
+    expect(result.data.entityClass).to.eq('animal');
+    expect(result.data.entityName).to.eq('cuteBambi');
+
+  });
+
+  it('correctly detects a PrismaCore a20 animalKilled event', () => {
+    const logLine = {
+      'date': '2017-11-14',
+      'time': '14:50:49',
+      'uptime': '133.559',
+      'msg': '[PrismaCore]entityKilled: Catalysm (Steam_76561198028175941) killed animal animalZombieDog with Dev: Instant Death Pistol',
       'trace': '',
       'type': 'Log'
     };

--- a/worker/processors/logs/handleLogLine.js
+++ b/worker/processors/logs/handleLogLine.js
@@ -274,7 +274,7 @@ module.exports = logLine => {
     returnValue.data = deathMessage;
   }
 
-  if (logLine.msg.startsWith('[CSMM_Patrons]playerLeveled:')) {
+  if (/^\[(CSMM_Patrons|PrismaCore)\]playerLeveled:/.test(logLine.msg)) {
     /*
     {
       "date": "2017-11-14",
@@ -312,7 +312,7 @@ module.exports = logLine => {
     returnValue.data = lvlMessage;
   }
 
-  if (logLine.msg.startsWith('[CSMM_Patrons]entityKilled:')) {
+  if (/^\[(CSMM_Patrons|PrismaCore)\]entityKilled:/.test(logLine.msg)) {
     /*
     {
       "date": "2017-11-14",


### PR DESCRIPTION
PrismaCore is the new name for the CPM (CSMM Patrons) mod. This update adds support for detecting servers running PrismaCore while maintaining full backward compatibility with the original CSMM_Patrons prefix.

Changes:
- Update mod version detection to check for both 'Mod PrismaCore' and 'Mod 1PrismaCore' variants alongside existing CPM patterns
- Add 'prismacore' parameter to API endpoint for explicit version queries
- Update log parsing regex to accept both [CSMM_Patrons] and [PrismaCore] prefixes for playerLeveled and entityKilled events
- Add comprehensive test coverage for all PrismaCore event formats

All existing functionality remains unchanged. Servers with CPM will continue to work exactly as before.